### PR TITLE
(PIE-405) Common HTTP functionality

### DIFF
--- a/lib/common_events_library/api/events.rb
+++ b/lib/common_events_library/api/events.rb
@@ -2,9 +2,8 @@ require_relative '../util/http'
 
 # module Events This contains the API specific code for the events API
 module Events
-  def get_all_events(token, pe_console, service = 'classifier', offset = 0, limit = 0)
-    auth_header = { 'X-Authentication' => token.to_s }
-    Http.get_request(pe_console, 4433, Http.make_params("activity-api/v1/events?service_id=#{service}", limit, offset), auth_header)
+  def get_all_events(token, pe_console, service = 'classifier', offset = 0, limit = 0, ssl_verify: true)
+    Http.get_request(pe_console, 4433, Http.make_params("activity-api/v1/events?service_id=#{service}", limit, offset), destination: 'pe', token: token, ssl_verify: ssl_verify)
   end
   module_function :get_all_events
 end

--- a/lib/common_events_library/api/orchestrator.rb
+++ b/lib/common_events_library/api/orchestrator.rb
@@ -2,15 +2,13 @@ require_relative '../util/http'
 
 # module Orchestrator this module provides the API specific code for accessing the orchestrator
 module Orchestrator
-  def get_all_jobs(token, pe_console)
-    auth_header = { 'X-Authentication' => token.to_s }
-    Http.get_request(pe_console, 8143, 'orchestrator/v1/jobs', auth_header)
+  def get_all_jobs(token, pe_console, ssl_verify: true)
+    Http.get_request(pe_console, 8143, 'orchestrator/v1/jobs', token: token, destination: 'pe', ssl_verify: ssl_verify)
   end
   module_function :get_all_jobs
 
-  def run_facts_task(token, pe_console, nodes, headers = {})
+  def run_facts_task(token, pe_console, nodes, ssl_verify: true)
     raise 'run_fact_tasks nodes param requires an array to be specified' unless nodes.is_a? Array
-    headers['X-Authentication'] = token.to_s
     body = {}
     body['environment'] = 'production'
     body['task'] = 'facts'
@@ -18,19 +16,17 @@ module Orchestrator
     body['scope'] = {}
     body['scope']['nodes'] = nodes
 
-    Http.post_request(pe_console, 8143, 'orchestrator/v1/command/task', body, headers)
+    Http.post_request(pe_console, 8143, 'orchestrator/v1/command/task', body, token: token, destination: 'pe', ssl_verify: ssl_verify)
   end
   module_function :run_facts_task
 
-  def run_job(token, pe_console, body, headers = {})
-    headers['X-Authentication'] = token.to_s
-    Http.post_request(pe_console, 8143, '/command/task', body, auth_header)
+  def run_job(token, pe_console, body, ssl_verify: true)
+    Http.post_request(pe_console, 8143, '/command/task', body, token: token, destination: 'pe', ssl_verify: ssl_verify)
   end
   module_function :run_job
 
-  def get_job(token, pe_console, job_id, limit = 0, offset = 0)
-    auth_header = { 'X-Authentication' => token.to_s }
-    Http.get_request(pe_console, 8143, Http.make_params("orchestrator/v1/jobs/#{job_id}", limit, offset), auth_header)
+  def get_job(token, pe_console, job_id, limit = 0, offset = 0, ssl_verify: true)
+    Http.get_request(pe_console, 8143, Http.make_params("orchestrator/v1/jobs/#{job_id}", limit, offset), token: token, destination: 'pe', ssl_verify: ssl_verify)
   end
   module_function :get_job
 

--- a/lib/common_events_library/util/http.rb
+++ b/lib/common_events_library/util/http.rb
@@ -5,11 +5,25 @@ require 'openssl'
 # module Http contains the http utilties for the common gem
 module Http
   # post_request takes a hash body and optional headers hash.
-  def post_request(hostname, port, uri, body, headers = {}, ssl_verify: true, ca_cert_path: nil)
+  # Specify either user/password or token/destination.
+  # Acceptable destination parameters are 'pe', 'sn', and 'splunk'.
+  # Token/destination will be used if both forms of auth are provided.
+  def post_request(hostname,
+                   port,
+                   uri,
+                   body,
+                   headers = {},
+                   ssl_verify: true,
+                   ca_cert_path: nil,
+                   user: nil,
+                   password: nil,
+                   destination: nil,
+                   token: nil,
+                   timeout: 60)
+
     headers['Content-Type'] = 'application/json' unless headers.key? 'Content-Type'
     hostname = hostname.prepend(hostname.start_with?('https://') ? '' : 'https://')
     uri = URI.parse("#{hostname}:#{port}/#{uri}")
-
     verify_mode = ssl_verify ? OpenSSL::SSL::VERIFY_PEER : OpenSSL::SSL::VERIFY_NONE
 
     http = Net::HTTP.start(
@@ -18,20 +32,49 @@ module Http
       use_ssl: uri.scheme == 'https',
       verify_mode: verify_mode,
       ca_file: ca_cert_path,
+      read_timeout:    timeout,
+      connect_timeout: timeout,
+      ssl_timeout:     timeout,
+      write_timeout:   timeout,
     )
 
     request = Net::HTTP::Post.new(uri.request_uri, headers)
-    request.body = body.to_json
 
+    # The PE token endpoint expects the password in the body
+    if body['password'].nil?
+      # prioritize OAuth
+      if token
+        oauth_header = make_oauth_header(destination, token)
+        request[oauth_header.keys.first] = oauth_header.values.first
+      else
+        # We use the basic_auth method to take advantage of the built in Base64 encoder.
+        request.basic_auth(user, password)
+      end
+    end
+
+    request.body = body.to_json
     http.request(request)
   end
   module_function :post_request
 
-  def get_request(hostname, port, uri, headers = {}, ssl_verify: true, ca_cert_path: nil)
+  # Specify either user/password or token/destination.
+  # Acceptable destination parameters are 'pe', 'sn', and 'splunk'.
+  # Token/destination will be used if both forms of auth are provided.
+  def get_request(hostname,
+                  port,
+                  uri,
+                  headers: {},
+                  ssl_verify: true,
+                  ca_cert_path: nil,
+                  user: nil,
+                  password: nil,
+                  destination: nil,
+                  token: nil,
+                  timeout: 60)
+
     headers['Content-Type'] = 'application/json' unless headers.key? 'Content-Type'
     hostname = hostname.prepend(hostname.start_with?('https://') ? '' : 'https://')
-    uri = URI.parse("https://#{hostname}:#{port}/#{uri}")
-
+    uri = URI.parse("#{hostname}:#{port}/#{uri}")
     verify_mode = ssl_verify ? OpenSSL::SSL::VERIFY_PEER : OpenSSL::SSL::VERIFY_NONE
 
     http = Net::HTTP.start(
@@ -40,26 +83,40 @@ module Http
       use_ssl: uri.scheme == 'https',
       verify_mode: verify_mode,
       ca_cert: ca_cert_path,
+      read_timeout:    timeout,
+      connect_timeout: timeout,
+      ssl_timeout:     timeout,
+      write_timeout:   timeout,
     )
 
     request = Net::HTTP::Get.new(uri.request_uri, headers)
+
+    # prioritize OAuth
+    if token
+      oauth_header = make_oauth_header(destination, token)
+      request[oauth_header.keys.first] = oauth_header.values.first
+    else
+      # We use the basic_auth method to take advantage of the built in Base64 encoder.
+      request.basic_auth(user, password)
+    end
 
     http.request(request)
   end
   module_function :get_request
 
-  def get_token(pe_console, username, password, ssl_verify: true, ca_cert_path: nil)
+  def get_pe_token(pe_console, username, password, ssl_verify: true, ca_cert_path: nil)
     response = post_request(
-      pe_console, 4433,
+      pe_console,
+      4433,
       'rbac-api/v1/auth/token',
       { 'login' => username, 'password' => password },
       ssl_verify: ssl_verify,
-      ca_cert_path: ca_cert_path
+      ca_cert_path: ca_cert_path,
     )
     token_hash = JSON.parse(response.body)
     token_hash['token']
   end
-  module_function :get_token
+  module_function :get_pe_token
 
   def make_params(uri, limit, offset)
     uri = "#{uri}?limit=#{limit}" unless limit.zero?
@@ -74,4 +131,19 @@ module Http
     JSON.parse(response.body)
   end
   module_function :response_to_hash
+
+  # This method prepares OAuth headers for a specified destination.
+  # Acceptable destination parameters are 'pe', 'sn', and 'splunk'.
+  def make_oauth_header(destination, token)
+    raise ArgumentError, "expects destination parameter to be 'pe', 'sn', or 'splunk'" unless ['pe', 'sn', 'splunk'].include?(destination.downcase)
+    case destination.downcase
+    when 'pe'
+      { 'X-Authentication' => token.to_s }
+    when 'sn'
+      { 'Authentication' => "Bearer #{token}" }
+    when 'splunk'
+      { 'Authorization' => "Splunk #{token}" }
+    end
+  end
+  module_function :make_oauth_header
 end


### PR DESCRIPTION
This adds support to the Http module for making requests via basic and
oauth auth for pe, servicenow, and splunk. This will help us keep our
Http code centralized in one place.