### PR TITLE
(MAINT) Fix https prepend

### DIFF
--- a/lib/common_events_library/util/http.rb
+++ b/lib/common_events_library/util/http.rb
@@ -22,7 +22,7 @@ module Http
                    timeout: 60)
 
     headers['Content-Type'] = 'application/json' unless headers.key? 'Content-Type'
-    nodename = hostname.start_with?('https://') ? '' : 'https://' + hostname
+    nodename = hostname.start_with?('https://') ? hostname : "https://#{hostname}"
     url = URI.parse("#{nodename}:#{port}/#{uri}")
     verify_mode = ssl_verify ? OpenSSL::SSL::VERIFY_PEER : OpenSSL::SSL::VERIFY_NONE
 
@@ -74,7 +74,7 @@ module Http
                   timeout: 60)
 
     headers['Content-Type'] = 'application/json' unless headers.key? 'Content-Type'
-    nodename = hostname.start_with?('https://') ? '' : 'https://' + hostname
+    nodename = hostname.start_with?('https://') ? hostname : "https://#{hostname}"
     url = URI.parse("#{nodename}:#{port}/#{uri}")
     verify_mode = ssl_verify ? OpenSSL::SSL::VERIFY_PEER : OpenSSL::SSL::VERIFY_NONE
 


### PR DESCRIPTION
This changes fixes a small bug that was causing host names to be set to
and empty string if they already had the https protocol at the beginning
of the hostname string.