### PR TITLE
(MAINT) Turn this repo back into a module

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -46,6 +46,19 @@ def servicenow_params(args)
   end
 end
 
+# Executes a command locally.
+#
+# @param command [String] command to execute.
+# @return [Object] the standard out stream.
+def run_local_command(command)
+  stdout, stderr, status = Open3.capture3(command)
+  error_message = "Attempted to run\ncommand:'#{command}'\nstdout:#{stdout}\nstderr:#{stderr}"
+  raise error_message unless status.to_i.zero?
+
+  stdout
+end
+
+
 PuppetLint.configuration.send('disable_relative')
 
 if Bundler.rubygems.find_name('github_changelog_generator').any?
@@ -324,4 +337,36 @@ namespace :acceptance do
       Rake::Task['acceptance:tear_down'].invoke
     end
   end
+end
+
+# Build the gem
+desc 'Build the gem'
+task :build do
+  gemspec_path = File.join(Dir.pwd, 'ruby-pwsh.gemspec')
+  run_local_command("bundle exec gem build '#{gemspec_path}'")
+end
+
+# Tag the repo with a version in preparation for the release
+#
+# @param :version [String] a semantic version to tag the code with
+# @param :sha [String] the sha at which to apply the version tag
+desc 'Tag the repo with a version in preparation for release'
+task :tag, [:version, :sha] do |_task, args|
+  raise "Invalid version #{args[:version]} - must be like '1.2.3'" unless args[:version] =~ /^\d+\.\d+\.\d+$/
+
+  run_local_command('git fetch upstream')
+  run_local_command("git tag -a #{args[:version]} -m #{args[:version]} #{args[:sha]}")
+  run_local_command('git push upstream --tags')
+end
+
+# Push the built gem to RubyGems
+#
+# @param :path [String] optional, the full or relative path to the built gem to be pushed
+desc 'Push to RubyGems'
+task :push, [:path] do |_task, args|
+  raise 'No discoverable gem for pushing' if Dir.glob("ruby-pwsh*\.gem").empty? && args[:path].nil?
+  raise "No file found at specified path: '#{args[:path]}'" unless File.exist?(args[:path])
+
+  path = args[:path] || File.join(Dir.pwd, Dir.glob("ruby-pwsh*\.gem")[0])
+  run_local_command("bundle exec gem push #{path}")
 end

--- a/examples/create_scheduled_task/examples.md
+++ b/examples/create_scheduled_task/examples.md
@@ -1,0 +1,11 @@
+# common_events_library::create_scheduled_task
+
+Before starting, ensure that if you are running these example from the module repository source code, you have run `bundle exec spec_prep` to ensure the fixtures directory is prepared with the correct file structure.
+
+Example 1. Using a params.json file to call with the task. Take special caer to notice the `--targets localhost` port of the Bolt invocation. This task is designed to be run from a workstation machine with no Bolt inventory file. All of the information the task needs to run is in the params.json file. An example params.json file is in this folder. The example task to schedule is `enterprise_tasks::verify_node` because that task takes parameters to demonstrate that this task is capable of passing parameters to the scheduled task.
+
+`bolt task run --format json --modulepath spec/fixtures/modules/ --targets localhost common_events_library::create_scheduled_task --params @task_params.json`
+
+Eample 2. Calling the task with no params.json file.
+
+`bolt task run --format json --modulepath spec/fixtures/modules/ --targets localhost common_events::create_scheduled_task task=facts username=admin password=pie interval=60 puppetserver=<Puppet server name> skip_cert_check=true`

--- a/examples/create_scheduled_task/task_params.json
+++ b/examples/create_scheduled_task/task_params.json
@@ -1,0 +1,13 @@
+{
+  "task": "enterprise_tasks::verify_node",
+  "task_params": {
+    "certname": "<Puppetserver name>",
+    "expected_type": "master",
+    "allow_failure": true
+  },
+  "description": "Bolt Created Task Schedule",
+  "username": "admin",
+  "password": "pie",
+  "puppetserver": "<Puppetserver name>",
+  "skip_cert_check": true
+}

--- a/metadata.json
+++ b/metadata.json
@@ -1,0 +1,71 @@
+{
+  "name": "common_events_library",
+  "version": "0.0.1",
+  "author": "Puppet, Inc.",
+  "summary": "A module that contains support for integration event reporting",
+  "license": "Apache-2.0",
+  "source": "http://github.com/puppetlabs/common_events_library",
+  "project_page": "http://github.com/puppetlabs/common_events_library",
+  "issues_url": "http://github.com/puppetlabs/common_events_library/issues",
+  "dependencies": [
+    {
+      "name": "puppetlabs/inifile",
+      "version_requirement": ">= 1.0.0 < 5.0.0"
+    },
+    {
+      "name": "puppetlabs/ruby_task_helper",
+      "version_requirement": ">= 0.3.0 <= 2.0.0"
+    }
+  ],
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "7",
+        "8"
+      ]
+    },
+    {
+      "operatingsystem": "OracleLinux",
+      "operatingsystemrelease": [
+        "7",
+        "8"
+      ]
+    },
+    {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "7",
+        "8"
+      ]
+    },
+    {
+      "operatingsystem": "Scientific",
+      "operatingsystemrelease": [
+        "7",
+        "8"
+      ]
+    },
+    {
+      "operatingsystem": "Ubuntu",
+      "operatingsystemrelease": [
+        "18.04"
+      ]
+    },
+    {
+      "operatingsystem": "SLES",
+      "operatingsystemrelease": [
+        "12"
+      ]
+    }
+  ],
+  "requirements": [
+    {
+      "name": "puppet",
+      "version_requirement": ">= 6.0.0 < 7.0.0"
+    }
+  ],
+  "pdk-version": "1.18.0",
+  "template-url": "pdk-default#1.18.0",
+  "template-ref": "tags/1.18.0-0-g095317c"
+}

--- a/tasks/create_scheduled_task.json
+++ b/tasks/create_scheduled_task.json
@@ -1,0 +1,67 @@
+{
+  "puppet_task_version": 1,
+  "supports_noop": false,
+  "description": "Create a task schedule to run the collector script",
+  "parameters": {
+    "task": {
+      "description": "Name of the task to run.",
+      "default": "facts",
+      "type": "String"
+    },
+    "task_params": {
+      "description": "Parameters to set for the task to be run.",
+      "type": "Optional[Hash]"
+    },
+    "description": {
+      "description": "The description for the task schedule",
+      "type": "Optional[String]"
+    },
+    "interval": {
+      "description": "Run interval in seconds.",
+      "type": "Integer",
+      "default": 60
+    },
+    "scheduled_time":{
+      "description": "Time to start running.",
+      "type": "Optional[String]"
+    },
+    "environment": {
+      "description": "The Puppet environment the Puppet server is in.",
+      "type": "String",
+      "default": "production"
+    },
+    "puppetserver": {
+      "description": "FQDN of the Puppet server to run the task on.",
+      "type": "String"
+    },
+    "auth_token": {
+      "description": "Puppet API auth token. If you don't have one, use username and password instead, and the task will obtain one for you.",
+      "type": "Optional[String]",
+      "sensitive": true
+    },
+    "username": {
+      "description": "A valid Puppet server username to create the schedule.",
+      "type": "Optional[String]"
+    },
+    "password":{
+      "description": "The password for the user to authorize to the Puppet api",
+      "type": "Optional[String]",
+      "sensitive": true
+    },
+    "ca_cert_path": {
+      "description": "The path to the ca certificate to trust the cert from the Puppet server.",
+      "type": "Optional[String]"
+    },
+    "skip_cert_check":{
+      "description": "Trust the Puppetserver ssl certificate without verification.",
+      "type": "Boolean",
+      "default": false
+    }
+  },
+  "files": [
+    "ruby_task_helper/files/task_helper.rb",
+    "common_events_library/lib/common_events_library/util/pe_http.rb",
+    "common_events_library/lib/common_events_library/util/common_events_http.rb"
+  ],
+  "input_method": "stdin"
+}

--- a/tasks/create_scheduled_task.rb
+++ b/tasks/create_scheduled_task.rb
@@ -1,0 +1,92 @@
+#!/usr/bin/env ruby
+require_relative '../../ruby_task_helper/files/task_helper.rb'
+require_relative '../lib/common_events_library/util/pe_http.rb'
+require 'uri'
+require 'net/http'
+require 'openssl'
+require 'json'
+require 'time'
+
+# CreateScheduledTask will construct a scheduled task in PE
+class CreateScheduledTask < TaskHelper
+  def task(
+    task:            nil,
+    task_params:     nil,
+    description:     nil,
+    interval:        60,
+    scheduled_time:  nil,
+    environment:     'production',
+    puppetserver:    nil,
+    auth_token:      nil,
+    username:        nil,
+    password:        nil,
+    ca_cert_path:    nil,
+    skip_cert_check: false,
+    **_kwargs
+  )
+
+    scheduled_time = scheduled_time.nil? ? Time.now + 30 : Time.parse(scheduled_time)
+    scheduled_time = scheduled_time.utc.iso8601
+
+    ssl_verify = !skip_cert_check
+
+    data = {
+      environment: environment,
+      task: task,
+      description: description,
+      params: task_params || {},
+      scope: {
+        nodes: [
+          puppetserver,
+        ],
+      },
+      scheduled_time: scheduled_time,
+      schedule_options: {
+        interval: {
+          units: 'seconds',
+          value: interval,
+        },
+      },
+    }
+
+    pe_client = PeHttp.new(
+      puppetserver,
+      port:         8143,
+      username:     username,
+      password:     password,
+      token:        auth_token,
+      ca_cert_path: ca_cert_path,
+      ssl_verify:   ssl_verify
+    )
+
+    # raise "#{data}"
+
+    response = pe_client.pe_post_request(
+      'orchestrator/v1/command/schedule_task',
+      data
+    )
+
+    if response.code == '202'
+      {
+        body:    JSON.parse(response.body),
+        code:    response.code,
+        message: response.message,
+      }
+    else
+      additional_info = {
+        body:        JSON.parse(response.body),
+        http_status: response.code,
+        message:     response.message,
+      }
+
+      raise TaskHelper::Error.new(
+        "Failed to create scheduled task: #{JSON.parse(response.body)['msg']}",
+        'common_integration_events/task-create-failure',
+        additional_info,
+      )
+
+    end
+  end
+end
+
+CreateScheduledTask.run if $PROGRAM_NAME == __FILE__

--- a/tasks/events.json
+++ b/tasks/events.json
@@ -1,0 +1,25 @@
+{
+  "puppet_task_version": 1,
+  "supports_noop": false,
+  "description": "This task scrapes the PE activity API for all events.",
+  "parameters": {
+      "pe_console": {
+        "description": "The FQDN of the PE console",
+        "type": "String[1]"
+      },
+      "pe_username": {
+        "description": "A PE user name",
+        "type": "Optional[String[1]]"
+      },
+      "pe_password": {
+        "description": "The PE console password",
+        "type": "Optional[String[1]]"
+      }
+  },
+  "input_method": "environment",
+  "files": [
+    "common_events_library/lib/common_events_library/util/pe_http.rb",
+    "common_events_library/lib/common_events_library/util/common_events_http.rb",
+    "common_events_library/lib/common_events_library/api/events.rb"
+  ]
+}

--- a/tasks/events.rb
+++ b/tasks/events.rb
@@ -1,0 +1,11 @@
+require_relative '../lib/common_events_library/api/events.rb'
+
+PE_CONSOLE = ENV['PT_pe_console']
+USERNAME = ENV['PT_pe_username'] || 'admin'
+PASSWORD = ENV['PT_pe_password'] || 'pie'
+
+raise 'usage: PT_PE_CONSOLE=<fqdn> events.rb' if PE_CONSOLE.nil?
+
+response = Events.get_all_events(PE_CONSOLE, USERNAME, PASSWORD, ssl_verify: false)
+
+puts JSON.pretty_generate(JSON.parse(response.body))

--- a/tasks/orchestrator.json
+++ b/tasks/orchestrator.json
@@ -1,0 +1,25 @@
+{
+  "puppet_task_version": 1,
+  "supports_noop": false,
+  "description": "This task scrapes the orchestrator for jobs",
+  "parameters": {
+      "pe_console": {
+        "description": "The FQDN of the PE console",
+        "type": "String[1]"
+      },
+      "pe_username": {
+        "description": "A PE user name",
+        "type": "Optional[String[1]]"
+      },
+      "pe_password": {
+        "description": "The PE console password",
+        "type": "Optional[String[1]]"
+      }
+  },
+  "input_method": "environment",
+  "files": [
+    "common_events_library/lib/common_events_library/util/pe_http.rb",
+    "common_events_library/lib/common_events_library/util/common_events_http.rb",
+    "common_events_library/lib/common_events_library/api/orchestrator.rb"
+  ]
+}

--- a/tasks/orchestrator.rb
+++ b/tasks/orchestrator.rb
@@ -1,0 +1,12 @@
+require_relative '../lib/common_events_library/api/orchestrator.rb'
+require 'benchmark'
+
+PE_CONSOLE = ENV['PT_pe_console']
+USERNAME = ENV['PT_pe_username'] || 'admin'
+PASSWORD = ENV['PT_pe_password'] || 'pie'
+
+raise 'usage: PT_PE_CONSOLE=<fqdn> events.rb' if PE_CONSOLE.nil?
+
+response = Orchestrator.get_all_jobs(PE_CONSOLE, USERNAME, PASSWORD, ssl_verify: false)
+
+puts response.body


### PR DESCRIPTION
We wanted to make this repo a ruby gem repository only. Unfortunately
that turns out to be a problem for Bolt. So this change brings back the
tasks that were moved out of the repo not that long ago.

It also updates some of the task metadata to ensure it will work
properly in the new structure.