### PR TITLE
(PIE-419) Convert api modules to classes

### DIFF
--- a/lib/common_events_library/api/classifier.rb
+++ b/lib/common_events_library/api/classifier.rb
@@ -2,17 +2,21 @@ require_relative '../util/pe_http'
 
 # module Classifier. This contains the API specific code to retreive information
 # from the classifier api.
-module Classifier
+class Classifier
+  attr_accessor :pe_client
+
+  def initialize(pe_console, username, password, ssl_verify: true)
+    @pe_client = PeHttp.new(pe_console, port: 4433, username: username, password: password, ssl_verify: ssl_verify)
+  end
+
   # Since we don't know exactly what we'll call these parameters yet this method
   # just fetches all parameters for a node. Eventually we plan to store job_ids,
   # pagination information, and possibly auth information for third party
   # services such as Splunk.
-  def get_node_parameters(pe_console, username, password, node, ssl_verify = false, offset = 0, limit = 0)
-    http = PeHttp.new(pe_console, port: 4433, username: username, password: password, ssl_verify: ssl_verify)
+  def get_node_parameters(node, offset = 0, limit = 0)
     uri = PeHttp.make_params("classifier-api/v1/classified/nodes/#{node}", limit, offset)
-    response = http.pe_get_request(uri)
+    response = pe_client.pe_get_request(uri)
     raise "Failed to retreive node parameters: #{response.code}, #{response.message}" if response.code.to_i > 200
     JSON.parse(response.body)['parameters']
   end
-  module_function :get_node_parameters
 end

--- a/lib/common_events_library/api/events.rb
+++ b/lib/common_events_library/api/events.rb
@@ -1,11 +1,15 @@
 require_relative '../util/pe_http'
 
 # module Events This contains the API specific code for the events API
-module Events
-  def get_all_events(pe_console, username, password, service = 'classifier', offset = 0, limit = 0, ssl_verify: true)
-    http = PeHttp.new(pe_console, port: 4433, username: username, password: password, ssl_verify: ssl_verify)
-    uri = PeHttp.make_params("activity-api/v1/events?service_id=#{service}", limit, offset)
-    http.pe_get_request(uri)
+class Events
+  attr_accessor :pe_client
+
+  def initialize(pe_console, username, password, ssl_verify: true)
+    @pe_client = PeHttp.new(pe_console, port: 4433, username: username, password: password, ssl_verify: ssl_verify)
   end
-  module_function :get_all_events
+
+  def get_all_events(service: 'classifier', offset: 0, limit: 0)
+    uri = PeHttp.make_params("activity-api/v1/events?service_id=#{service}", limit, offset)
+    pe_client.pe_get_request(uri)
+  end
 end

--- a/tasks/create_scheduled_task.rb
+++ b/tasks/create_scheduled_task.rb
@@ -56,14 +56,12 @@ class CreateScheduledTask < TaskHelper
       password:     password,
       token:        auth_token,
       ca_cert_path: ca_cert_path,
-      ssl_verify:   ssl_verify
+      ssl_verify:   ssl_verify,
     )
-
-    # raise "#{data}"
 
     response = pe_client.pe_post_request(
       'orchestrator/v1/command/schedule_task',
-      data
+      data,
     )
 
     if response.code == '202'

--- a/tasks/events.rb
+++ b/tasks/events.rb
@@ -6,6 +6,7 @@ PASSWORD = ENV['PT_pe_password'] || 'pie'
 
 raise 'usage: PT_PE_CONSOLE=<fqdn> events.rb' if PE_CONSOLE.nil?
 
-response = Events.get_all_events(PE_CONSOLE, USERNAME, PASSWORD, ssl_verify: false)
+events_client = Events.new(PE_CONSOLE, USERNAME, PASSWORD, ssl_verify: false)
+response = events_client.get_all_events
 
 puts JSON.pretty_generate(JSON.parse(response.body))

--- a/tasks/orchestrator.rb
+++ b/tasks/orchestrator.rb
@@ -7,6 +7,7 @@ PASSWORD = ENV['PT_pe_password'] || 'pie'
 
 raise 'usage: PT_PE_CONSOLE=<fqdn> events.rb' if PE_CONSOLE.nil?
 
-response = Orchestrator.get_all_jobs(PE_CONSOLE, USERNAME, PASSWORD, ssl_verify: false)
+orchestrator_client = Orchestrator.new(PE_CONSOLE, USERNAME, PASSWORD, ssl_verify: false)
+response = orchestrator_client.get_all_jobs
 
 puts response.body


### PR DESCRIPTION
This changes converts the api modules to classes in order to use an init
method to create the http object which can be reused.