### PR TITLE
(MAINT) Fix pagination.

### DIFF
--- a/lib/common_events_library/api/classifier.rb
+++ b/lib/common_events_library/api/classifier.rb
@@ -14,7 +14,7 @@ class Classifier
   # pagination information, and possibly auth information for third party
   # services such as Splunk.
   def get_node_parameters(node, offset = 0, limit = 0)
-    uri = PeHttp.make_params("classifier-api/v1/classified/nodes/#{node}", limit, offset)
+    uri = PeHttp.make_pagination_params("classifier-api/v1/classified/nodes/#{node}", limit, offset)
     response = pe_client.pe_get_request(uri)
     raise "Failed to retreive node parameters: #{response.code}, #{response.message}" if response.code.to_i > 200
     JSON.parse(response.body)['parameters']

--- a/lib/common_events_library/api/events.rb
+++ b/lib/common_events_library/api/events.rb
@@ -9,7 +9,7 @@ class Events
   end
 
   def get_all_events(service: 'classifier', offset: 0, limit: 0)
-    uri = PeHttp.make_params("activity-api/v1/events?service_id=#{service}", limit, offset)
+    uri = PeHttp.make_pagination_params("activity-api/v1/events?service_id=#{service}", limit, offset)
     pe_client.pe_get_request(uri)
   end
 end

--- a/lib/common_events_library/api/orchestrator.rb
+++ b/lib/common_events_library/api/orchestrator.rb
@@ -32,7 +32,7 @@ class Orchestrator
   end
 
   def get_job(job_id, limit = 0, offset = 0)
-    uri = PeHttp.make_params("orchestrator/v1/jobs/#{job_id}", limit, offset)
+    uri = PeHttp.make_pagination_params("orchestrator/v1/jobs/#{job_id}", limit, offset)
     pe_client.pe_get_request(uri)
   end
 

--- a/lib/common_events_library/util/common_events_http.rb
+++ b/lib/common_events_library/util/common_events_http.rb
@@ -70,12 +70,20 @@ class CommonEventsHttp
     port ? "#{hostname}:#{port}" : hostname
   end
 
-  def self.make_params(uri, limit, offset)
-    return_uri = "#{uri}?limit=#{limit}" unless limit.zero?
-    return_uri = "#{uri}&offset=#{offset}" unless offset.zero? && limit
-    return_uri = "#{uri}?offset=#{offset}" unless offset.zero? && limit.zero?
-    return_uri = uri if return_uri.nil?
-    return_uri
+  # Takes the uri and a hash of param names like { param_name => param_value }.
+  # Returns a formatted uri string with params.
+  def self.make_params(uri, params)
+    uri + '?' + params.map { |name, value| "#{name}=#{value}" }.join('&')
+  end
+
+  # Makes a hash of the limit and offset, and filters the zeros.
+  def self.make_pagination_hash(limit, offset)
+    pagination_hash = { 'limit' => limit, 'offset' => offset }
+    pagination_hash.select {|name, value| value > 0}
+  end
+
+  def self.make_pagination_params(uri, limit, offset)
+    make_params(uri, make_pagination_hash(limit, offset))
   end
 
   def self.response_to_hash(response)


### PR DESCRIPTION
Previously only the offset would be included if both a limit and offset
were specified. This adds a few separate method including one to create
a param string from a hash of params, one the create a hash of limit and
offset params, and one to combine the two into a convinience method.