### PR TITLE
(MAINT) Revert spec.yaml

### DIFF
--- a/.github/workflows/spec.yaml
+++ b/.github/workflows/spec.yaml
@@ -21,7 +21,7 @@ jobs:
         ruby-version: ${{ matrix.ruby_version }}
 
     - name: Spec Tests
-      uses: RandomNoun7/action-litmus_spec@MAINT-fix-user-install-bug
+      uses: puppetlabs/action-litmus_spec@master
       with:
         puppet_gem_version: ${{ matrix.puppet_gem_version }}
         check: ${{ matrix.check }}


### PR DESCRIPTION
The required fix has been merged into the puppetlabs namespaced repo.
Revert this change to go back to using the correct actions reference.