### PR TITLE
(MAINT) Fix gem --user-install bug

### DIFF
--- a/.github/workflows/spec.yaml
+++ b/.github/workflows/spec.yaml
@@ -21,7 +21,7 @@ jobs:
         ruby-version: ${{ matrix.ruby_version }}
 
     - name: Spec Tests
-      uses: RandomNoun7/action-litmus_spec@change_env_exports
+      uses: RandomNoun7/action-litmus_spec@MAINT-fix-user-install-bug
       with:
         puppet_gem_version: ${{ matrix.puppet_gem_version }}
         check: ${{ matrix.check }}


### PR DESCRIPTION
The litmus_spec action uses the `--user-install` switch when installing
the `bundler` gem. This installs it to a directory that is not on the
PATH. Subsequent calls to `bundler` like `bundler -v` then fail and
cause the ci run to fail.

This change switches to a personal fork of the action that removes that
call.

When a fix for this bug is implemented in the upstream action repo this
change should be removed to point at the puppetlabs copy of the action.