### PR TITLE
(PIE-451) Fix the make_params function for limit and offset being zero

### DIFF
--- a/lib/common_events_library/util/common_events_http.rb
+++ b/lib/common_events_library/util/common_events_http.rb
@@ -73,7 +73,7 @@ class CommonEventsHttp
   # Takes the uri and a hash of param names like { param_name => param_value }.
   # Returns a formatted uri string with params.
   def self.make_params(uri, params)
-    uri + '?' + params.map { |name, value| "#{name}=#{value}" }.join('&')
+    params.empty? ? uri : uri + '?' + params.map { |name, value| "#{name}=#{value}" }.join('&')
   end
 
   # Makes a hash of the limit and offset, and filters the zeros.

--- a/spec/unit/util/common_events_http_spec.rb
+++ b/spec/unit/util/common_events_http_spec.rb
@@ -13,6 +13,7 @@ describe 'Common Events Http' do
     expect(CommonEventsHttp.make_pagination_params('orchestrator/v1/jobs', 5, 2)).to eq('orchestrator/v1/jobs?limit=5&offset=2')
     expect(CommonEventsHttp.make_pagination_params('orchestrator/v1/jobs', 0, 2)).to eq('orchestrator/v1/jobs?offset=2')
     expect(CommonEventsHttp.make_pagination_params('orchestrator/v1/jobs', 5, 0)).to eq('orchestrator/v1/jobs?limit=5')
+    expect(CommonEventsHttp.make_pagination_params('orchestrator/v1/jobs', 0, 0)).to eq('orchestrator/v1/jobs')
   end
 
   it 'can convert a response to a hash' do


### PR DESCRIPTION
The uri had a ? appended to it when it had a limit and offset of zero.
Added a new unit test to cover it.