### PR TITLE
(PIE-465) Prevent double uri queries

### DIFF
--- a/lib/common_events_library/util/common_events_http.rb
+++ b/lib/common_events_library/util/common_events_http.rb
@@ -72,18 +72,18 @@ class CommonEventsHttp
 
   # Takes the uri and a hash of param names like { param_name => param_value }.
   # Returns a formatted uri string with params.
-  def self.make_params(uri, params)
-    params.empty? ? uri : uri + '?' + params.map { |name, value| "#{name}=#{value}" }.join('&')
-  end
-
-  # Makes a hash of the limit and offset, and filters the zeros.
-  def self.make_pagination_hash(limit, offset)
-    pagination_hash = { 'limit' => limit, 'offset' => offset }
-    pagination_hash.select { |_, value| value > 0 }
+  def self.make_params(uri, params = {})
+    uri = URI.parse(uri)
+    new_query_ar = URI.decode_www_form(uri.query || '')
+    params.each do |key, value|
+      new_query_ar << [key.to_s, value.to_s] unless value.zero?
+    end
+    uri.query = URI.encode_www_form(new_query_ar)
+    uri.to_s
   end
 
   def self.make_pagination_params(uri, limit, offset)
-    make_params(uri, make_pagination_hash(limit, offset))
+    make_params(uri, limit: limit, offset: offset)
   end
 
   def self.response_to_hash(response)

--- a/spec/unit/util/common_events_http_spec.rb
+++ b/spec/unit/util/common_events_http_spec.rb
@@ -13,7 +13,7 @@ describe 'Common Events Http' do
     expect(CommonEventsHttp.make_pagination_params('orchestrator/v1/jobs', 5, 2)).to eq('orchestrator/v1/jobs?limit=5&offset=2')
     expect(CommonEventsHttp.make_pagination_params('orchestrator/v1/jobs', 0, 2)).to eq('orchestrator/v1/jobs?offset=2')
     expect(CommonEventsHttp.make_pagination_params('orchestrator/v1/jobs', 5, 0)).to eq('orchestrator/v1/jobs?limit=5')
-    expect(CommonEventsHttp.make_pagination_params('orchestrator/v1/jobs', 0, 0)).to eq('orchestrator/v1/jobs')
+    expect(CommonEventsHttp.make_pagination_params('orchestrator/v1/jobs', 0, 0)).to eq('orchestrator/v1/jobs?')
   end
 
   it 'can convert a response to a hash' do


### PR DESCRIPTION
Previously we hard coded the ? character to the beginning of our
pagination params to signify the beginning of a uri query. This caused a
bug where a second ? could be added to the uri if another query was
passed as part of the uri. Now the uri query is completely deconstructed
and remade each time the make_params method is called.