### PR TITLE
(PIE-475) Allow Events and Orchestrator classes to accept auth token.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The common events library is a module makes it easier to gather events from Pupp
 
 ```ruby
 require 'common_events_library'
-orchestrator  = Orchestrator.new(pe_console_url, pe_username, pe_password, ssl_verify: false)
+orchestrator  = Orchestrator.new(pe_console_url, username: pe_username, password: pe_password, ssl_verify: false)
 
 # Get the last ten orchestrator jobs
 response = orchestrator.get_all_jobs(offset: 0, limit: 10)
@@ -34,13 +34,15 @@ The code above will create an orchestrator client that can get all available job
 
 ```ruby
 require 'common_events_library'
-events = Events.new(pe_console_url, pe_username, pe_password, ssl_verify: false)
+events = Events.new(pe_console_url, username: pe_username, password: pe_password, ssl_verify: false)
+# Alternatively, if you wish to authenticate with a token:
+events = Events.new(pe_console_url, token: pe_token, ssl_verify: false)
 
 # Get the last ten rbac service events
 response = events.get_all_events(service: 'rbac', limit: 10)
 ```
 
-The code above will create an Activity Service API client that can get events from the `activity-api/v1/events` end point. The `service` parameter is the name of an Activity API `service_id` which can be any of `classifier`, `rbac`, `pe-console` or `code-manager`.
+The code above will create an Activity Service API client that can get events from the `activity-api/v1/events` end point. The `service` parameter is the name of an Activity API `service_id` which can be any of `classifier`, `rbac`, `pe-console` or `code-manager`. If you provide a username, password, and token, the token will be used.
 
 ### Create a General Purpose HTTP Client for Sending Data
 

--- a/lib/common_events_library/api/events.rb
+++ b/lib/common_events_library/api/events.rb
@@ -4,8 +4,8 @@ require_relative '../util/pe_http'
 class Events
   attr_accessor :pe_client
 
-  def initialize(pe_console, username, password, ssl_verify: true)
-    @pe_client = PeHttp.new(pe_console, port: 4433, username: username, password: password, ssl_verify: ssl_verify)
+  def initialize(pe_console, username: nil, password: nil, token: nil, ssl_verify: true)
+    @pe_client = PeHttp.new(pe_console, port: 4433, username: username, password: password, token: token, ssl_verify: ssl_verify)
   end
 
   def get_events(service: nil, offset: nil, limit: nil)

--- a/lib/common_events_library/api/orchestrator.rb
+++ b/lib/common_events_library/api/orchestrator.rb
@@ -4,8 +4,8 @@ require_relative '../util/pe_http'
 class Orchestrator
   attr_accessor :pe_client
 
-  def initialize(pe_console, username, password, ssl_verify: true)
-    @pe_client = PeHttp.new(pe_console, port: 8143, username: username, password: password, ssl_verify: ssl_verify)
+  def initialize(pe_console, username: nil, password: nil, token: nil, ssl_verify: true)
+    @pe_client = PeHttp.new(pe_console, port: 8143, username: username, password: password, token: token, ssl_verify: ssl_verify)
   end
 
   def get_jobs(limit: nil, offset: nil, order: nil, order_by: nil)


### PR DESCRIPTION
Modify the Events and Orchestrator classes to accept an auth token in
order to prevent a sensitive username and password from being stored in
a config file. In this scenario the user provides their own long lived
auth token rather than having the PEHTTP class generate one. Users are
still able to use a username and password if desired.