### PR TITLE
(PIE-654) Implement Lock File

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -36,9 +36,6 @@ Style/BlockDelimiters:
   Description: Prefer braces for chaining. Mostly an aesthetical choice. Better to
     be consistent then.
   EnforcedStyle: braces_for_chaining
-Style/ClassAndModuleChildren:
-  Description: Compact style reduces the required amount of indentation.
-  EnforcedStyle: compact
 Style/EmptyElse:
   Description: Enforce against empty else clauses, but allow `nil` for clarity.
   EnforcedStyle: empty

--- a/files/collect_api_events.rb
+++ b/files/collect_api_events.rb
@@ -6,7 +6,7 @@ def require_classes(modulepaths)
   catch :done do
     modulepaths.split(':').each do |modulepath|
       Find.find(modulepath) do |path|
-        if path.match?(%r{common_events_library.gemspec})
+        if %r{common_events_library.gemspec}.match?(path)
           $LOAD_PATH.unshift("#{File.dirname(path)}/lib")
           throw :done
         end
@@ -14,21 +14,36 @@ def require_classes(modulepaths)
     end
   end
 
+  require 'events_collection/lockfile'
   require 'events_collection/orchestrator_event'
   require 'common_events_library'
 end
 
-def main(confdir, modulepaths)
+def main(confdir, modulepaths, statedir)
   require_classes(modulepaths)
 
-  settings = YAML.safe_load(File.read("#{confdir}/events_collection.yaml"))
-
-  orchestrator_client = Orchestrator.new('localhost', username: settings['pe_username'], password: settings['pe_password'], token: settings['pe_token'], ssl_verify: false)
-  puts orchestrator_client.get_jobs(limit: 1)
+  begin
+    lockfile = CommonEvents::Lockfile.new(statedir)
+    settings = YAML.safe_load(File.read("#{confdir}/events_collection.yaml"))
+    if lockfile.already_running?
+      puts 'already running'
+    else
+      lockfile.write_lockfile
+      orchestrator_client = Orchestrator.new('localhost', username: settings['pe_username'], password: settings['pe_password'], token: settings['pe_token'], ssl_verify: false)
+      puts orchestrator_client.get_jobs(limit: 1)
+      # Find any compatible reports
+      # Reports should be in /lib/reports/common_events
+    end
+  rescue => exception
+    puts exception
+  ensure
+    lockfile.remove_lockfile
+  end
 end
 
 if $PROGRAM_NAME == __FILE__
-  confdir     = ARGV[0]
-  modulepaths = ARGV[1]
-  main(confdir, modulepaths)
+  confdir     = ARGV[0] || '/etc/puppetlabs/puppet'
+  modulepaths = ARGV[1] || '/etc/puppetlabs/code/environments/production/modules:/etc/puppetlabs/code/environments/production/site:/etc/puppetlabs/code/modules:/opt/puppetlabs/puppet/modules'
+  statedir    = ARGV[2] || '/etc/puppetlabs/puppet'
+  main(confdir, modulepaths, statedir)
 end

--- a/lib/events_collection/lockfile.rb
+++ b/lib/events_collection/lockfile.rb
@@ -1,0 +1,53 @@
+require 'json'
+
+module CommonEvents
+  # Manages the Lockfile.
+  class Lockfile
+    attr_accessor :filepath
+
+    def initialize(basepath)
+      @filepath = File.join(basepath, 'events_collection_run.lock')
+    end
+
+    def lockfile_exists?
+      File.exist? filepath
+    end
+
+    def info
+      if lockfile_exists?
+        JSON.parse(File.read(filepath))
+      else
+        { pid: nil, program_name: '' }
+      end
+    end
+
+    def write_lockfile
+      raise 'Cannot acquire lock. Lockfile already exists.' if lockfile_exists? && info['pid']
+      body = {
+        pid:          Process.pid,
+        program_name: $PROGRAM_NAME,
+      }
+
+      File.write(filepath, body.to_json)
+    end
+
+    def remove_lockfile
+      raise 'Cannot delete Lockfile. Does not exist.' unless lockfile_exists?
+      File.delete(filepath)
+    end
+
+    def already_running?
+      pid = info['pid']
+      pid.nil? ? false : validate_command(pid)
+    end
+
+    def validate_command(pid)
+      command = File.read("/proc/#{pid}/cmdline")
+      !info['program_name'].match(%r{#{command}}).nil?
+    rescue
+      # Remove lock if the process is no longer running.
+      remove_lockfile
+      false
+    end
+  end
+end

--- a/spec/support/acceptance/install_pe.sh
+++ b/spec/support/acceptance/install_pe.sh
@@ -5,7 +5,7 @@ version=`puppet --version`
 if [ -z "$version" ]; then
   PE_RELEASE=2019.8.1
   PE_LATEST=$(curl https://artifactory.delivery.puppetlabs.net/artifactory/generic_enterprise__local/archives/releases/${PE_RELEASE}/LATEST)
-  PE_FILE_NAME=puppet-enterprise-${PE_LATEST}-el-7-x86_64
+  PE_FILE_NAME=puppet-enterprise-${PE_LATEST}-ubuntu-18.04-amd64
   TAR_FILE=${PE_FILE_NAME}.tar
   DOWNLOAD_URL=https://artifactory.delivery.puppetlabs.net/artifactory/generic_enterprise__local/archives/releases/${PE_RELEASE}/${TAR_FILE}
 

--- a/spec/unit/events_collection/lockfile_spec.rb
+++ b/spec/unit/events_collection/lockfile_spec.rb
@@ -1,0 +1,96 @@
+require_relative '../../../lib/events_collection/lockfile'
+
+describe 'Lockfile' do
+  let(:basepath) { '/tmp' }
+  let(:path) { File.join('/tmp', 'events_collection_run.lock') }
+  let(:new_lockfile) { CommonEvents::Lockfile.new(basepath) }
+
+  before(:each) do
+    File.delete(path) if File.exist?(path)
+  end
+
+  it 'sets the correct lockfile path' do
+    filepaths = ['/path/path', '/path/', '/path', 'path', '']
+    filepaths.each do |filepath|
+      expect(CommonEvents::Lockfile.new(filepath).filepath).to eq(File.join(filepath, '/events_collection_run.lock'))
+      File.delete(filepath) if File.exist?(filepath)
+    end
+  end
+
+  it 'requires a lockfile path' do
+    expect { CommonEvents::Lockfile.new }.to raise_error(ArgumentError)
+  end
+
+  it 'creates the lockfile with the correct format' do
+    new_lockfile.write_lockfile
+    expect(File.exist?(path)).to be true
+    lockfile_contents = JSON.parse(File.read(path))
+    expect(lockfile_contents['pid']).to be_an(Integer)
+    expect(lockfile_contents['program_name']).to be_a(String)
+  end
+
+  it 'checks if the lockfile exists' do
+    lockfile = new_lockfile
+    expect(lockfile.lockfile_exists?).to be false
+    lockfile.write_lockfile
+    expect(lockfile.lockfile_exists?).to be true
+  end
+
+  it 'can delete the lockfile' do
+    lockfile = new_lockfile
+    lockfile.write_lockfile
+    expect(File.exist?(path)).to be true
+    lockfile.remove_lockfile
+    expect(File.exist?(path)).to be false
+  end
+
+  it 'returns lockfile info correctly' do
+    lockfile = new_lockfile
+    expect(lockfile.info).to eql({ pid: nil, program_name: '' })
+    lockfile.write_lockfile
+    expect(lockfile.info['pid']).to be_an(Integer)
+    expect(lockfile.info['program_name']).to be_a(String)
+    File.delete(path)
+    expect(lockfile.info).to eql({ pid: nil, program_name: '' })
+  end
+
+  it 'does not overwrite the lockfile' do
+    lockfile = new_lockfile
+    lockfile.write_lockfile
+    expect { lockfile.write_lockfile }.to raise_error('Cannot acquire lock. Lockfile already exists.')
+  end
+
+  it 'will raise an error if a lock tries to be deleted more than once' do
+    # An error here will alert us to the fact
+    # that locks are are not behaving correctly.
+    lockfile = new_lockfile
+    lockfile.write_lockfile
+    lockfile.remove_lockfile
+    expect { lockfile.remove_lockfile }.to raise_error('Cannot delete Lockfile. Does not exist.')
+  end
+
+  it 'removes the lock if validate_command fails' do
+    lockfile = new_lockfile
+    bogus_body = {
+      pid:          555,
+      program_name: 'test',
+    }
+    File.write(path, bogus_body.to_json)
+    expect(lockfile.already_running?).to be(false)
+    expect(lockfile.lockfile_exists?).to be(false)
+  end
+
+  context 'checks if the process id is already running' do
+    it 'with a current lock' do
+      lockfile = new_lockfile
+      allow(lockfile).to receive(:validate_command).and_return('validate_command')
+      lockfile.write_lockfile
+      # Ensure that we are calling validate_command rather than returning false.
+      expect(lockfile.already_running?).to eql('validate_command')
+    end
+    it 'without a current lock' do
+      lockfile = new_lockfile
+      expect(lockfile.already_running?).to be(false)
+    end
+  end
+end


### PR DESCRIPTION
The coordinator script should wake up and be able to tell if the
previous run has completed. It should then write it's own lock file
to prevent a subsequent concurrent run.

The lock file should be fault tolerant and not leave an orphan lock
file if the script encounters an error.

It should also write enough information to the file so that the script
is not confused if the operating system reuses the PID in the case
that an orphan PID file is left behind for some reason.