### PR TITLE
PIE-764 Refactor Index class

### DIFF
--- a/files/collect_api_events.rb
+++ b/files/collect_api_events.rb
@@ -17,21 +17,23 @@ def main(confdir, _modulepaths, statedir)
   else
     lockfile.write_lockfile
     orchestrator_client = CommonEvents::Orchestrator.new('localhost', username: settings['pe_username'], password: settings['pe_password'], token: settings['pe_token'], ssl_verify: false)
-    orchestrator_index = CommonEvents::Index.new(statedir, 'orchestrator')
+    everything_index = CommonEvents::Index.new(statedir)
     current_count = orchestrator_client.current_job_count
 
-    puts orchestrator_index.count
+    puts everything_index.read_count(:orchestrator)
     puts current_count
-    new_count = orchestrator_index.new_items(current_count)
+    new_count = everything_index.new_items(:orchestrator, current_count)
     puts new_count
-    orchestrator_index.save_latest_index(current_count)
+    everything_index.save_latest_index(:orchestrator, current_count)
 
-    events_index = CommonEvents::Index.new(statedir, 'events')
-    puts "events count: #{events_index.count}"
-    events_index.save_latest_index(15)
-    puts "events count 2: #{events_index.count}"
+    puts "classifier count: #{everything_index.read_count(:classifier)}"
+    everything_index.save_latest_index(:classifier, 15)
+    everything_index.save_latest_index(:rbac, 3)
+    everything_index.save_latest_index(:pe_console, 5)
+    everything_index.save_latest_index(:code_manager, 7)
+    puts "classifier count 2: #{everything_index.read_count(:classifier)}"
 
-    puts File.read(events_index.filepath)
+    puts File.read(everything_index.filepath)
 
     # Find any compatible reports
     # Reports should be in /lib/reports/common_events

--- a/files/util/index.rb
+++ b/files/util/index.rb
@@ -1,43 +1,47 @@
 module CommonEvents
   # CommonEvents Index utility class for storing and tracking index numbers
   class Index
-    attr_accessor :filepath, :index_type
-    def initialize(statedir, index_type)
+    attr_accessor :filepath
+    def initialize(statedir)
       require 'yaml'
       @filepath = "#{statedir}/common_events_indexes.yaml"
-      @index_type = index_type
+
       create_new_index_file unless File.exist? @filepath
     end
 
     def create_new_index_file
-      tracker = { @index_type => 0 }
-      File.write(@filepath, tracker.to_yaml)
-      @count = 0
+      tracker = { classifier:   0,
+                  rbac:         0,
+                  pe_console:   0,
+                  code_manager: 0,
+                  orchestrator: 0, }
+      File.write(filepath, tracker.to_yaml)
     end
 
-    def count
-      @count ||= read_count
+    def counts
+      @counts ||= YAML.safe_load(File.read('tracker.yaml'), [Symbol])
     end
 
-    def read_count
-      tracker = YAML.safe_load(File.read(@filepath))
-      tracker[@index_type] || 0
+    def read_count(index_type)
+      tracker = YAML.safe_load(File.read(filepath), [Symbol])
+      tracker[index_type] || 0
     end
 
-    def new_items(latest_count)
-      diff = latest_count - count
-      diff > 0 ? diff : 0
+    def new_items(index_type, latest_count)
+      diff = latest_count - read_count(index_type)
+      raise 'Got negative value for new_items' unless diff >= 0
+      diff
     end
 
     def index_hash
-      YAML.safe_load(File.read(@filepath))
+      YAML.safe_load(File.read(filepath), [Symbol])
     end
 
-    def save_latest_index(latest)
+    def save_latest_index(index_type, latest)
       data = index_hash
-      data[@index_type] = latest
-      File.write(@filepath, data.to_yaml)
-      @count = nil
+      data[index_type] = latest
+      File.write(filepath, data.to_yaml)
+      @counts = data
     end
   end
 end

--- a/spec/unit/util/common_events/index_spec.rb
+++ b/spec/unit/util/common_events/index_spec.rb
@@ -1,7 +1,7 @@
 require_relative '../../../../files/util/index'
 
 describe CommonEvents::Index do
-  subject(:index) { described_class.new(statedir, index_type) }
+  subject(:index) { described_class.new(statedir) }
 
   let(:statedir)   { 'blah' }
   let(:index_type) { 'foo' }
@@ -9,7 +9,7 @@ describe CommonEvents::Index do
   let(:yaml) do
     <<~YAML
       ---
-      foo: 10
+      :foo: 10
     YAML
   end
 
@@ -25,7 +25,7 @@ describe CommonEvents::Index do
       end
 
       it 'creates a new file with correct content' do
-        expect(File).to receive(:write).with(filepath, "---\nfoo: 0\n")
+        expect(File).to receive(:write).with(filepath, "---\n:classifier: 0\n:rbac: 0\n:pe_console: 0\n:code_manager: 0\n:orchestrator: 0\n")
         index
       end
     end
@@ -41,27 +41,27 @@ describe CommonEvents::Index do
   context '.create_new_index_file' do
     before(:each) { allow(File).to receive(:write) }
     it 'creates the correct file' do
-      expect(File).to receive(:write).with(filepath, "---\nfoo: 0\n")
+      expect(File).to receive(:write).with(filepath, "---\n:classifier: 0\n:rbac: 0\n:pe_console: 0\n:code_manager: 0\n:orchestrator: 0\n")
       index.create_new_index_file
     end
 
     it 'sets current count to zero' do
       index.create_new_index_file
-      expect(index.count).to be(0)
+      expect(index.counts).to eq(foo: 10)
     end
   end
 
-  context '.count' do
+  context '.counts' do
     it 'retreives current count' do
-      index.instance_variable_set(:@count, 5)
-      expect(index.count).to be(5)
+      index.instance_variable_set(:@counts, 5)
+      expect(index.counts).to eq(5)
     end
   end
 
   context '.read_count' do
     context 'with valid yaml' do
       it 'retreives correct count' do
-        expect(index.read_count).to be(10)
+        expect(index.read_count(:foo)).to be(10)
       end
     end
 
@@ -75,19 +75,19 @@ describe CommonEvents::Index do
       end
 
       it 'throw an error for invalid yaml' do
-        expect { index.read_count }.to raise_error(Psych::SyntaxError)
+        expect { index.read_count(:foo) }.to raise_error(Psych::SyntaxError)
       end
     end
   end
 
   context '.save_latest_index' do
     before(:each) do
-      allow(File).to receive(:read).and_return({ 'foo' => 15 }.to_yaml)
+      allow(File).to receive(:read).and_return({ foo: 15 }.to_yaml)
     end
 
     it 'writes correct yaml' do
       expect(File).to receive(:write).with(filepath, yaml)
-      index.save_latest_index(10)
+      index.save_latest_index(:foo, 10)
     end
   end
 end


### PR DESCRIPTION
Refactored the index class so that we don't need to create new instances
of the index class for every service_name endpoint. Initialize no longer
takes the service_name as param, but the sub functions do.