### PR TITLE
(PIE-761) Implement Search for Processors

### DIFF
--- a/files/util/processor.rb
+++ b/files/util/processor.rb
@@ -1,0 +1,29 @@
+module CommonEvents
+  # A class for finding processors and then invoking them.
+  # This class should also capture output streams for later logging.
+  class Processor
+    require 'find'
+    require 'open3'
+
+    attr_accessor :path, :stdout, :stderr, :status, :name
+    def initialize(path)
+      @path = path
+      @name = path.split('/')[-1]
+    end
+
+    def invoke
+      @stdout, @stderr, @status = Open3.capture3(@path)
+    end
+
+    def self.find_each(dir)
+      return [] unless File.exist? dir
+      processors = Find.find(dir).map do |path|
+        unless FileTest.directory?(path)
+          CommonEvents::Processor.new(path)
+        end
+      end
+
+      processors.compact
+    end
+  end
+end

--- a/rakelib/helpers.rake
+++ b/rakelib/helpers.rake
@@ -25,6 +25,17 @@ def task_prefix(hostname)
 end
 
 namespace :acceptance do
+  desc 'Upload Test Processors'
+  task :upload_processors do
+    ['proc1.sh', 'proc2.rb'].each do |processor|
+      proc_path = "spec/support/acceptance/#{processor}"
+      folder = '/etc/puppetlabs/puppet/common_events/processors.d'
+      server.run_shell("mkdir -p #{folder}")
+      server.bolt_upload_file(proc_path, folder)
+      server.run_shell("chmod +x #{folder}/#{processor}")
+    end
+  end
+
   desc 'Provisions the VMs. This is currently just the server'
   task :provision_vms do
     if File.exist?('../spec/fixtures/litmus_inventory.yaml')

--- a/spec/spec_helper_local.rb
+++ b/spec/spec_helper_local.rb
@@ -1,5 +1,13 @@
+require 'spec_helper'
+
 RSpec.configure do |c|
   c.mock_with :rspec
 end
 
 FULL_MODULE_PATH = "#{Dir.pwd}/spec/fixtures/modules".freeze
+
+def procs_paths
+  base_path = "#{Dir.pwd}/spec/support/"
+  Dir.children('./spec/support').map { |p| "#{base_path}#{p}" } +
+    Dir.children('spec/support/acceptance').map { |p| "#{base_path}#{p}" }
+end

--- a/spec/support/acceptance/proc1.sh
+++ b/spec/support/acceptance/proc1.sh
@@ -1,0 +1,9 @@
+#! /bin/bash
+
+echo 'hello world!' > /tmp/proc1
+
+echo 'stdoutstreamhere'
+
+echo 'errorstreamhereagain' 1>&2
+
+exit 20

--- a/spec/support/acceptance/proc2.rb
+++ b/spec/support/acceptance/proc2.rb
@@ -1,0 +1,9 @@
+#!/opt/puppetlabs/puppet/bin/ruby
+
+File.write('/tmp/proc2', 'hello world!')
+
+puts 'done processing'
+
+STDERR.puts('stderrmessage')
+
+exit 5

--- a/spec/unit/util/common_events/processor_spec.rb
+++ b/spec/unit/util/common_events/processor_spec.rb
@@ -1,0 +1,79 @@
+require 'spec_helper_local'
+require_relative '../../../../files/util/processor'
+require 'open3'
+require 'find'
+
+describe CommonEvents::Processor do
+  subject(:processor) { described_class.new(path) }
+
+  let(:path)      { '/tmp/blah/processors.d/proc1.sh' }
+  let(:procs_dir) { '/tmp/blah/processors.d' }
+
+  let(:invoke_result) do
+    return 'stdout_message', 'stderr_message', 0
+  end
+
+  before(:each) do
+    allow(Open3).to receive(:capture3).with(path).and_return(invoke_result)
+  end
+
+  context '#find_each' do
+    context 'processors directory exists' do
+      before(:each) do
+        allow(File).to receive(:exist?).with(procs_dir).and_return(true)
+      end
+
+      context 'processors in the directory' do
+        before(:each) do
+          allow(Find).to receive(:find).with(procs_dir).and_return(procs_paths)
+        end
+
+        it 'returns correct number of processors' do
+          expect(described_class.find_each(procs_dir).count).to eq(4)
+        end
+
+        it 'returns correct object types' do
+          described_class.find_each(procs_dir).each do |processor|
+            expect(processor.class).to be(described_class)
+          end
+        end
+      end
+
+      context 'no processors present' do
+        before(:each) do
+          allow(Find).to receive(:find).with(procs_dir).and_return([])
+        end
+
+        it 'returns no processors' do
+          expect(described_class.find_each(procs_dir).count).to eq(0)
+        end
+      end
+    end
+  end
+
+  context '.initialize' do
+    it 'has full path property' do
+      expect(processor.path).to eq(path)
+    end
+
+    it 'has correct name property' do
+      expect(processor.name).to eq('proc1.sh')
+    end
+  end
+
+  context '.invoke' do
+    before(:each) { processor.invoke }
+
+    it 'populates stdout' do
+      expect(processor.stdout).to eq('stdout_message')
+    end
+
+    it 'populates stderr' do
+      expect(processor.stderr).to eq('stderr_message')
+    end
+
+    it 'populates exit code' do
+      expect(processor.status).to eq(0)
+    end
+  end
+end


### PR DESCRIPTION
This change adds a class that knows how to search a specified directory
at only the first level looking for files, but not search recursively
through directories. Those directories may contain support library files
for the processors, not processors.

This class can then be created from a file path and it knows how to
invoke a processor and capture its output streams and exit code.

That data can then be accessed for logging purposes.