### PR TITLE
PIE-758 Add get event count to events client

### DIFF
--- a/files/api/events.rb
+++ b/files/api/events.rb
@@ -20,5 +20,10 @@ module CommonEvents
       raise 'Events API request failed' unless response.code == '200'
       response.body
     end
+
+    def current_event_count(service_name)
+      events_count_for_service = get_events(service: service_name, limit: 1)
+      JSON.parse(events_count_for_service)['total-rows'] || 0
+    end
   end
 end

--- a/files/util/index.rb
+++ b/files/util/index.rb
@@ -10,11 +10,11 @@ module CommonEvents
     end
 
     def create_new_index_file
-      tracker = { classifier:   0,
-                  rbac:         0,
-                  pe_console:   0,
-                  code_manager: 0,
-                  orchestrator: 0, }
+      tracker = { classifier:     0,
+                  rbac:           0,
+                  'pe-console':   0,
+                  'code-manager': 0,
+                  orchestrator:   0, }
       File.write(filepath, tracker.to_yaml)
     end
 

--- a/spec/unit/util/common_events/index_spec.rb
+++ b/spec/unit/util/common_events/index_spec.rb
@@ -25,7 +25,7 @@ describe CommonEvents::Index do
       end
 
       it 'creates a new file with correct content' do
-        expect(File).to receive(:write).with(filepath, "---\n:classifier: 0\n:rbac: 0\n:pe_console: 0\n:code_manager: 0\n:orchestrator: 0\n")
+        expect(File).to receive(:write).with(filepath, "---\n:classifier: 0\n:rbac: 0\n:pe-console: 0\n:code-manager: 0\n:orchestrator: 0\n")
         index
       end
     end
@@ -41,7 +41,7 @@ describe CommonEvents::Index do
   context '.create_new_index_file' do
     before(:each) { allow(File).to receive(:write) }
     it 'creates the correct file' do
-      expect(File).to receive(:write).with(filepath, "---\n:classifier: 0\n:rbac: 0\n:pe_console: 0\n:code_manager: 0\n:orchestrator: 0\n")
+      expect(File).to receive(:write).with(filepath, "---\n:classifier: 0\n:rbac: 0\n:pe-console: 0\n:code-manager: 0\n:orchestrator: 0\n")
       index.create_new_index_file
     end
 


### PR DESCRIPTION
Added function to events.rb to get the current total event count for the
specified service name.

Added quotations for two of the service names in index.rb to fix the
name. (pe_console -> pe-console, code_manager -> code-manager)