### PR TITLE
(PIE-525) HSBC Defect - First Run Protection

### DIFF
--- a/files/util/index.rb
+++ b/files/util/index.rb
@@ -5,6 +5,7 @@ module CommonEvents
     def initialize(statedir)
       require 'yaml'
       @filepath = "#{statedir}/common_events_indexes.yaml"
+      @first_run = false
 
       new_index_file unless File.exist? @filepath
     end
@@ -16,6 +17,11 @@ module CommonEvents
                   'code-manager': 0,
                   orchestrator:   0, }
       File.write(filepath, tracker.to_yaml)
+      @first_run = true
+    end
+
+    def first_run?
+      @first_run
     end
 
     def counts(refresh: false)

--- a/spec/unit/util/common_events/index_spec.rb
+++ b/spec/unit/util/common_events/index_spec.rb
@@ -30,6 +30,10 @@ describe CommonEvents::Index do
         expect(File).not_to receive(:write)
         index
       end
+
+      it 'returns false on first_run? call' do
+        expect(index.first_run?).to be false
+      end
     end
   end
 
@@ -43,6 +47,11 @@ describe CommonEvents::Index do
     it 'sets current count to zero' do
       index.new_index_file
       expect(index.counts).to eq(index_data)
+    end
+
+    it 'sets first_run to false' do
+      index.new_index_file
+      expect(index.first_run?).to be true
     end
   end
 


### PR DESCRIPTION
When the module is first started it should not send every event in the
api all at once. It should realize this is the first time it's running,
note the number of available events in the index file and then shut
down.

On the next run it should then only send the new events since that first
run.