### PR TITLE
(PIE-759) Moved make_params call to pe_http class

### DIFF
--- a/files/api/activity.rb
+++ b/files/api/activity.rb
@@ -18,8 +18,7 @@ module CommonEvents
         offset:     offset,
         order:      order,
       }
-      uri = CommonEvents::PeHttp.make_params('activity-api/v2/events', params)
-      response = pe_client.pe_get_request(uri)
+      response = pe_client.pe_get_request('activity-api/v2/events', params)
       raise 'Events API request failed' unless response.code == '200'
       JSON.parse(response.body)
     end

--- a/files/api/orchestrator.rb
+++ b/files/api/orchestrator.rb
@@ -17,9 +17,7 @@ module CommonEvents
         order:    order,
         order_by: order_by,
       }
-
-      uri = CommonEvents::PeHttp.make_params('orchestrator/v1/jobs', params)
-      response = pe_client.pe_get_request(uri)
+      response = pe_client.pe_get_request('orchestrator/v1/jobs', params)
       raise 'Orchestrator API request failed' unless response.code == '200'
       JSON.parse(response.body)
     end

--- a/files/util/pe_http.rb
+++ b/files/util/pe_http.rb
@@ -28,7 +28,8 @@ module CommonEvents
     end
 
     # Wrapper method for get_request that includes a token auth header for PE.
-    def pe_get_request(uri, headers = {}, timeout = 60)
+    def pe_get_request(uri, params, headers = {}, timeout = 60)
+      uri = Http.make_params(uri, params)
       get_request(uri, headers.merge(pe_auth_header), timeout)
     end
 


### PR DESCRIPTION
Removed call to the make_params method from orchestrator and activity
Pe_http can now build the URI internally