### PR TITLE
(MAINT) Update location of test processors

### DIFF
--- a/rakelib/helpers.rake
+++ b/rakelib/helpers.rake
@@ -28,7 +28,7 @@ namespace :acceptance do
   desc 'Upload Test Processors'
   task :upload_processors do
     ['proc1.sh', 'proc2.rb'].each do |processor|
-      proc_path = "spec/support/acceptance/#{processor}"
+      proc_path = "spec/support/acceptance/processors/#{processor}"
       folder = '/etc/puppetlabs/puppet/common_events/processors.d'
       server.run_shell("mkdir -p #{folder}")
       server.bolt_upload_file(proc_path, folder)


### PR DESCRIPTION
The upload_processors rake task had an old path to install the test
processors onto the puppet server. It has been updated.