### PR TITLE
MAINT - Fix Quoting Typo

### DIFF
--- a/files/collect_api_events.rb
+++ b/files/collect_api_events.rb
@@ -53,7 +53,7 @@ def main(confdir, logpath, lockdir)
       data[service] = activities.current_event_count(service)
     end
     index.save(data)
-    log.debug('First run. Recorded event count in #{index.filepath} and now exiting.')
+    log.debug("First run. Recorded event count in #{index.filepath} and now exiting.")
     exit
   end
 


### PR DESCRIPTION
Fixed one of the log entries that had single quotes to double
quotes so interpolation works correctly now.