### PR TITLE
(MAINT) Fix recursive directory search

### DIFF
--- a/files/util/processor.rb
+++ b/files/util/processor.rb
@@ -23,12 +23,17 @@ module CommonEvents
 
     def self.find_each(dir)
       return [] unless File.exist? dir
-      Find.find(dir).select do |path|
+      dir_listing(dir).select do |path|
         unless FileTest.directory?(path)
           processor = CommonEvents::Processor.new(path)
           block_given? ? yield(processor) : processor
         end
       end
+    end
+
+    # Tiny little wrapper to make test mocks easier.
+    def self.dir_listing(dir)
+      Dir["#{dir}/*"]
     end
   end
 end

--- a/spec/unit/util/common_events/processor_spec.rb
+++ b/spec/unit/util/common_events/processor_spec.rb
@@ -23,7 +23,7 @@ describe CommonEvents::Processor do
 
       context 'processors in the directory' do
         before(:each) do
-          allow(Find).to receive(:find).with(procs_dir).and_return(procs_paths)
+          allow(described_class).to receive(:dir_listing).with(procs_dir).and_return(procs_paths)
         end
 
         it 'returns correct number of processors' do


### PR DESCRIPTION
Directory searches were being done recursively. We don't want that to
happen because processors are allowed to write their own sub directories
and the files inside those directories should not be considered
processors themselves.