### PR TITLE
(MAINT) Move base config directory

### DIFF
--- a/files/collect_api_events.rb
+++ b/files/collect_api_events.rb
@@ -11,7 +11,7 @@ require_relative 'util/index'
 require_relative 'util/processor'
 require_relative 'util/logger'
 
-confdir   = ARGV[0] || '/etc/puppetlabs/puppet/common_events'
+confdir   = ARGV[0] || '/etc/puppetlabs/common_events'
 logpath   = ARGV[1] || '/var/log/puppetlabs/common_events/common_events.log'
 lockdir   = ARGV[2] || '/opt/puppetlabs/common_events/cache/state'
 

--- a/lib/puppet/functions/common_events/base_path.rb
+++ b/lib/puppet/functions/common_events/base_path.rb
@@ -2,7 +2,7 @@ Puppet::Functions.create_function(:'common_events::base_path') do
   def base_path(str, path)
     # No specific path is provided, going to use default path from logdir
     if path.nil?
-      base = str[%r{^(.*?)puppetlabs}]
+      base = str[%r{^(.*?)\/puppetlabs\/}]
       !base.nil? ? base : str
     # A specfic path is provided
     else

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,7 +18,7 @@ class common_events (
   Optional[String]                                $cron_monthday    = '*',
   Optional[String]                                $log_path         = undef,
   Optional[String]                                $lock_path        = undef,
-  Optional[String]                                $confdir          = "${settings::confdir}/common_events",
+  Optional[String]                                $confdir          = "${common_events::base_path($settings::confdir,undef)}/common_events",
   Enum['DEBUG', 'INFO', 'WARN', 'ERROR', 'FATAL'] $log_level        = 'WARN',
   Enum['NONE', 'DAILY', 'WEEKLY', 'MONTHLY']      $log_rotation     = 'NONE',
 ){

--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -5,7 +5,7 @@ require 'support/acceptance/helpers.rb'
 include PuppetLitmus
 PuppetLitmus.configure!
 
-CONFDIR = '/etc/puppetlabs/puppet'.freeze
+CONFDIR = '/etc/puppetlabs'.freeze
 LOGDIR  = '/var/log/puppetlabs/common_events'.freeze
 LOCKFILEDIR = '/opt/puppetlabs/common_events/cache/state'.freeze
 


### PR DESCRIPTION
This change removes common_events feature files from the `puppet`
subdirectory under `/etc/puppetlabs`. Having files in the directory
implied that they were a part of core Puppet functionality.