### PR TITLE
(PIE-905) Add supported versions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ This module is capable of gathering events data and invoking processors from non
 
 9. The script exits.
 
+## Compatible PE Versions
+
+This module is compatible with PE versions in the 2019 range starting at 2019.8.7 and above, and then 2021 versions from 2021.2 and above.
+
+Versions in the PE 2019 series below 2019.8.7 and in the 2021 series in versions below 2021.2 did not recieve an update to some of the API methods in PE that are required for this module to function properly.
+
 ## Writing an Event Forwarding Processor
 
 An event forwarding processor is any script or executable binary that:

--- a/metadata.json
+++ b/metadata.json
@@ -58,7 +58,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 6.0.0 < 7.0.0"
+      "version_requirement": ">= 6.23.0 < 8.0.0"
     }
   ],
   "pdk-version": "2.2.0",


### PR DESCRIPTION
This module needs a feature in the PE API that was added starting at
Puppet 6.23.0, but was not added to 7 series puppet until 7.8.0.

This means there is a gap in the version numbers that have this feature
that currently includes 7.4.1 and 7.6.1.

The forge does not have a supported method to represent a disjoint
set of version ranges like this. Our only choice is to specify a version
range that includes both of those versions, and then specify in the
README as clearly as possible, that there is a set of version numbers
within that range that we cannot support.

Specifically the feature is support for sorting activities by oldest to
newest in the events end point.

It appears first in 2019.8.7 (puppet 6.23.0)
https://puppet.com/docs/pe/2019.8/release_notes_pe.html#enhancements_pe_x-y-7-sort-activities

And then for the first time in the 2021 series at 2021.2 (puppet 7.8.0)
 https://puppet.com/docs/pe/2021.3/release_notes_pe.html#enhancements_pe_x-2-sort-activities
(Yes the link above says 2021.3, but the page itself has the release
notes for all of the 2021 series, and this feature is in the section
for 2021.2)