### PR TITLE
(MAINT) Fix unit tests on github actions

### DIFF
--- a/spec/unit/util/pe_event_forwarding/lockfile_spec.rb
+++ b/spec/unit/util/pe_event_forwarding/lockfile_spec.rb
@@ -72,7 +72,7 @@ describe PeEventForwarding::Lockfile do
   it 'removes the lock if validate_command fails' do
     lockfile = new_lockfile
     bogus_body = {
-      pid:          555,
+      pid:          9999,
       program_name: 'test',
     }
     File.write(path, bogus_body.to_json)


### PR DESCRIPTION
It looks like the fake PID we were using in the unit tests is now being
used on a regular basis and causing pull request pipelines to fail.

This change uses a different pid so that tests can pass.