### PR TITLE
(PIE-1664) reset index on first run fail

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -5,7 +5,7 @@ on: [pull_request]
 jobs:
   setup_matrix:
     name: "Setup Test Matrix"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.build-matrix.outputs.matrix }}
 
@@ -47,7 +47,7 @@ jobs:
     needs:
       - setup_matrix
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.setup_matrix.outputs.matrix) }}

--- a/files/collect_api_events.rb
+++ b/files/collect_api_events.rb
@@ -60,6 +60,7 @@ def main(confdir, logpath, lockdir)
 
   if index.first_run?
     if settings['skip_jobs'].nil?
+      log.debug("Starting orchestrator for first run with #{index.count(:orchestrator)} event(s)")
       data[:orchestrator] = orchestrator.current_job_count(timeout)
     end
     service_names.each do |service|

--- a/files/util/index.rb
+++ b/files/util/index.rb
@@ -5,9 +5,14 @@ module PeEventForwarding
     def initialize(statedir)
       require 'yaml'
       @filepath = "#{statedir}/pe_event_forwarding_indexes.yaml"
-      @first_run = false
 
-      new_index_file unless File.exist? @filepath
+      # In the event that the first run failed, the index file will exist with all values set to 0.
+      # When this occurs we treat subsequent runs as the first, until the current count is logged.
+      if File.exist? @filepath
+        @first_run = YAML.safe_load(File.read(@filepath), permitted_classes: [Symbol]).values.all? { |value| value == 0 }
+      else
+        new_index_file
+      end
     end
 
     def new_index_file

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -8,7 +8,7 @@ describe 'Verify the minimum install' do
   end
 
   after(:all) do
-    set_sitepp_content(declare('class', 'pe_event_forwarding', { 'pe_token' => auth_token, 'disabled' => true }))
+    set_sitepp_content(declare('class', 'pe_event_forwarding', { 'pe_token' => auth_token, 'disabled' => true, 'log_level' => 'DEBUG' }))
     trigger_puppet_run(puppetserver)
   end
 

--- a/spec/acceptance/index_spec.rb
+++ b/spec/acceptance/index_spec.rb
@@ -12,19 +12,25 @@ describe 'index file' do
 
   it 'writes expected keys' do
     index_contents = puppetserver.run_shell("cat #{CONFDIR}/pe_event_forwarding/pe_event_forwarding_indexes.yaml").stdout
-    index = YAML.safe_load(index_contents, [Symbol])
+    index = YAML.safe_load(index_contents, permitted_classes: [Symbol])
     [:classifier, :rbac, :'pe-console', :'code-manager', :orchestrator].each do |key|
       expect(index.keys.include?(key)).to be true
     end
   end
 
+  it 'treats run as the first when first_run failed' do
+    index_fail_reset
+    first_run_count = puppetserver.run_shell("grep 'first run' #{LOGDIR}/pe_event_forwarding.log -c", expect_failures: true).stdout.to_i
+    expect(first_run_count).to eql(6)
+  end
+
   it 'updates orchestrator index value' do
     index_contents = puppetserver.run_shell("cat #{CONFDIR}/pe_event_forwarding/pe_event_forwarding_indexes.yaml").stdout
-    index          = YAML.safe_load(index_contents, [Symbol])
+    index          = YAML.safe_load(index_contents, permitted_classes: [Symbol])
     current_value  = index[:orchestrator]
     puppetserver.run_shell("LC_ALL=en_US.UTF-8 puppet task run facts --nodes #{console_host_fqdn}")
     index_contents = puppetserver.run_shell("#{CONFDIR}/pe_event_forwarding/collect_api_events.rb ; cat #{CONFDIR}/pe_event_forwarding/pe_event_forwarding_indexes.yaml").stdout
-    index = YAML.safe_load(index_contents, [Symbol])
+    index = YAML.safe_load(index_contents, permitted_classes: [Symbol])
     updated_value = index[:orchestrator]
     expect(updated_value).to eql(current_value + 1)
   end

--- a/spec/support/acceptance/helpers.rb
+++ b/spec/support/acceptance/helpers.rb
@@ -33,9 +33,9 @@ class Target
   # most recently set the TARGET_HOST variable.
   PuppetLitmus.instance_methods.each do |name|
     m = PuppetLitmus.instance_method(name)
-    define_method(name) do |*args, &block|
+    define_method(name) do |*args, **kwargs, &block|
       ENV['TARGET_HOST'] = uri
-      m.bind(self).call(*args, &block)
+      m.bind(self).call(*args, **kwargs, &block)
     end
   end
 

--- a/spec/unit/util/pe_event_forwarding/index_spec.rb
+++ b/spec/unit/util/pe_event_forwarding/index_spec.rb
@@ -26,7 +26,7 @@ describe PeEventForwarding::Index do
     end
 
     context 'file does exist' do
-      it 'creates a new file with correct content' do
+      it 'does not create a new file' do
         expect(File).not_to receive(:write)
         index
       end
@@ -49,7 +49,7 @@ describe PeEventForwarding::Index do
       expect(index.counts).to eq(index_data)
     end
 
-    it 'sets first_run to false' do
+    it 'sets first_run to true' do
       index.new_index_file
       expect(index.first_run?).to be true
     end
@@ -85,7 +85,7 @@ describe PeEventForwarding::Index do
 
     it 'updates @counts' do
       expect(File).to receive(:write).with(filepath, index_yaml(foo: 10))
-      expect(File).to receive(:read).once
+      expect(File).to receive(:read).twice
       index.save(foo: 10)
       expect(index.count(:foo)).to eq(10)
     end


### PR DESCRIPTION
# Summary

This commit ensures that in the event the first collection run fails, subsequent runs are treated as the first until event counts are successfully saved to the index.

# Detailed Description

`files/collect_api_events.rb`
  * Added a DEBUG log entry for orchestrator during first run.

`files/util/index.rb`
  * Set `@first_run` to true when the index contains all 0 values.

`spec/acceptance/index_spec.rb`
  * Add a test to ensure `@first_run` is set properly when the index contains all 0 values.

`spec/spec_helper_acceptance_local.rb`
  * Added function to help facilitate the spec test.

`spec/support/acceptance/helpers.rb`
  * Added double splat `**kwargs` for Ruby 3 [compatibility](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/).

`spec/unit/util/pe_event_forwarding/index_spec.rb`
  * Updates to account for changes in `@first_run` variable assignment.