### PR TITLE
(PIE-1683) Add support for collecting plan data

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -18,4 +18,3 @@ fixtures:
     translate: 'https://github.com/puppetlabs/puppetlabs-translate'
     provision: 'https://github.com/puppetlabs/provision'
     litmus: 'https://github.com/puppetlabs/litmus'
-    deploy_pe: 'https://github.com/jarretlavallee/puppet-deploy_pe'

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
     - name: Checkout Source
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       if: ${{ github.repository_owner == 'puppetlabs' }}
 
     - name: Activate Ruby 3.1
@@ -35,8 +35,9 @@ jobs:
         --provision-exclude docker \
         --arch-exclude arm \
         --platform-exclude debian \
+        --platform-exclude redhat-8 \
         --platform-exclude sles \
-        --platform-exclude ubuntu \
+        --platform-exclude 'ubuntu-(20|24).04' \
         --puppet-exclude 7 \
         --puppet-exclude 8 \
         --pe-include
@@ -53,7 +54,7 @@ jobs:
 
     steps:
     - name: Checkout Source
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Activate Ruby 3.1
       uses: ruby/setup-ruby@v1
@@ -94,15 +95,12 @@ jobs:
     - name: Install server
       run: |
         bundle exec bolt --modulepath spec/fixtures/modules plan run pe_event_forwarding::acceptance::pe_server version='${{ matrix.collection }}' -i ./$INVENTORY_PATH --stream
-    - name: Add localhost target to inventory
-      run: |
-        bundle exec rake 'acceptance:add_localhost_target'
     - name: Install module
       run: |
         bundle exec rake 'litmus:install_module'
     - name: Run acceptance tests
       run: |
-        bundle exec rake acceptance:run_tests
+        bundle exec rake acceptance:ci_run_tests
     - name: Remove test environment
       if: ${{ always() }}
       continue-on-error: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.ref }}
           clean: true

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
     - name: Checkout Source
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       if: ${{ github.repository_owner == 'puppetlabs' }}
 
     - name: Activate Ruby 3.1
@@ -55,7 +55,7 @@ jobs:
 
     steps:
     - name: Checkout Source
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
 
     - name: "Activate Ruby ${{ matrix.ruby_version }}"
       uses: ruby/setup-ruby@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to this project will be documented in this file. The format 
 
 [Current Diff](https://github.com/puppetlabs/puppetlabs-pe_event_forwarding/compare/v2.2.0..main)
 
+### Added
+
+- Plan job data collection from the `orchestrator/v1/plan_jobs` API. Progress is tracked independently via a dedicated state file `pe_event_forwarding_plan_index.yaml`.
+
+- Added parameter `pe_event_forwarding::skip_plans` to disable plan job collection from the `orchestrator/v1/plan_jobs` API.
+
+### Fixed
+
+- Issue with `get_jobs` where the first page request could return more job records than the number of new jobs available, causing duplicate data to be forwarded.
+
 ## [v2.2.0](https://github.com/puppetlabs/puppetlabs-pe_event_forwarding/tree/v2.1.0) (2025-07-15)
 
 [Full Changelog](https://github.com/puppetlabs/puppetlabs-pe_event_forwarding/compare/v2.1.0..v2.2.0)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 ## Intro
 
-This module gathers events from the [Puppet Jobs API](https://puppet.com/docs/pe/latest/orchestrator_api_jobs_endpoint.html#get_jobs) and the [Activities API]( https://puppet.com/docs/pe/latest/activity_api_events.html#activity-api-v2-get-events) using a script executed by a cron job. This data is provided to any available processor scripts during each run. The scripts are provided by any modules that want to make use of this data such as the [puppetlabs-splunk_hec](https://forge.puppet.com/modules/puppetlabs/splunk_hec) module. These processor scripts then handle the data they are given and forward it on to their respective platforms.
+This module gathers events from the [Puppet Jobs API](https://puppet.com/docs/pe/latest/orchestrator_api_jobs_endpoint.html#get_jobs), the [Plan Jobs API](https://help.puppet.com/pe/current/topics/orchestrator_api_get_plan_jobs.htm), and the [Activities API]( https://puppet.com/docs/pe/latest/activity_api_events.html#activity-api-v2-get-events) using a script executed by a cron job. This data is provided to any available processor scripts during each run. The scripts are provided by any modules that want to make use of this data such as the [puppetlabs-splunk_hec](https://forge.puppet.com/modules/puppetlabs/splunk_hec) module. These processor scripts then handle the data they are given and forward it on to their respective platforms.
 
 #### Compatible PE Versions
 
@@ -97,6 +97,12 @@ A processor should implement the following workflow when invoked:
         "events": [
             ...
         ]
+    },
+    "orchestrator_plan": {
+        "last_finished": "2025-01-01T00:00:00Z",
+        "events": [
+            ...
+        ]
     }
 }
 ```
@@ -126,10 +132,10 @@ data = JSON.parse(data_file_path)
 events = []
 
 # Iterate over event types
-['orchestrator', 'rbac', 'classifier', 'pe-console', 'code-manager'].each do |index|
+['orchestrator', 'orchestrator_plan', 'rbac', 'classifier', 'pe-console', 'code-manager'].each do |index|
     # Add each type's events to the array
-    # A nil value indicates that there were no new events.
-    # A negative value indicates that the sourcetype has been disabled from the pe_event_forwarding module.
+    # A negative value indicates that collection has been disabled. A nil value indicates that there were no new events.
+    # Note: orchestrator_plan is never set to -1; it is absent (nil) when skip_plans is true or there are no new plan job events.
     next if data[index].nil? || data[index] == -1
     events << data[index]['events']
 end
@@ -229,6 +235,8 @@ Inside that directory will be:
 
 * Index tracking file `pe_event_forwarding_indexes.yaml`.
 
+* Plan index tracking file `pe_event_forwarding_plan_index.yaml`.
+
 * Subdirectory for ruby class files `api`.
 
 * Subdirectory for utilities files consumed by the classes `util`.
@@ -263,7 +271,15 @@ During event collection, this optional array will be considered to determine if 
 
 `skip_jobs`
 
-Setting this variable to true will skip all orchestrator events. This is useful for instances where there is a large enough quantity of orchestrator data to create a performance issue. When disabled, the orchestrator index will show as `-1` in the `pe_event_forwarding_indexes.yaml` file. When re-enabling the `skip_jobs` variable, only new orchestrator events will be processed moving forward. It will take one run of the cron job (of the `collect_api_events.rb`) to resume event processing and recreate the orchestrator index. All other event types will be unaffected.
+Setting this variable to true will skip all orchestrator events. This is useful for instances where there is a large enough quantity of orchestrator data to create a performance issue. When disabled, the orchestrator index will show as `-1` in the `pe_event_forwarding_indexes.yaml` file. To re-enable collection remove the `skip_jobs` parameter or set it to **false**. Only new orchestrator events will be processed moving forward. It will take one run of the cron job (of the `collect_api_events.rb`) to resume event processing and recreate the orchestrator index. All other event types will be unaffected.
+
+---
+
+`skip_plans`
+
+Setting this variable to true will skip all orchestrator plan job events. This is useful for instances where there is a large enough quantity of plan job data to create a performance issue. When disabled, the `orchestrator_plan` key will be absent from the processor payload entirely (unlike `skip_jobs` and `skip_events` which set the value to `-1`). To re-enable collection remove the `skip_plans` parameter or set it to **false**. Only new plan job events will be processed moving forward. It will take one run of the cron job (of the `collect_api_events.rb`) to resume event processing and recreate the plan index. Plan job collection is tracked in a separate state file `pe_event_forwarding_plan_index.yaml`. All other event types will be unaffected.
+
+**Note**: With `skip_plans` set to **true**, individual task data associated with the plan is still collected under orchestrator events.
 
 ---
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -66,6 +66,7 @@ The following parameters are available in the `pe_event_forwarding` class:
 * [`api_page_size`](#-pe_event_forwarding--api_page_size)
 * [`timeout`](#-pe_event_forwarding--timeout)
 * [`skip_jobs`](#-pe_event_forwarding--skip_jobs)
+* [`skip_plans`](#-pe_event_forwarding--skip_plans)
 * [`skip_events`](#-pe_event_forwarding--skip_events)
 
 ##### <a name="-pe_event_forwarding--pe_username"></a>`pe_username`
@@ -217,6 +218,14 @@ Default value: `undef`
 Data type: `Optional[Boolean]`
 
 When true, event collection from the Orchestrator API is disabled.
+
+Default value: `undef`
+
+##### <a name="-pe_event_forwarding--skip_plans"></a>`skip_plans`
+
+Data type: `Optional[Boolean]`
+
+When true, event collection from the Orchestrator plan_jobs API is disabled.
 
 Default value: `undef`
 

--- a/files/api/activity.rb
+++ b/files/api/activity.rb
@@ -29,9 +29,10 @@ module PeEventForwarding
         response       = pe_client.pe_get_request(API_END_POINT, params, timeout)
         response_body  = JSON.parse(response.body)
         total_count    = response_body['pagination']['total']
-        response_body['commits']&.map { |commit| response_items << commit }
+        commits        = response_body['commits']
+        commits&.each { |commit| response_items << commit }
 
-        break if response_body['commits'].nil? || response_body['commits'].count != api_page_size
+        break if commits.nil? || commits.count != api_page_size
         params[:offset] += api_page_size
       end
       log.debug("PE Get Events Items Found: #{service}: #{response_items.count}")

--- a/files/api/orchestrator.rb
+++ b/files/api/orchestrator.rb
@@ -1,4 +1,5 @@
 require_relative '../util/pe_http'
+require 'time'
 
 module PeEventForwarding
   # module Orchestrator this module provides the API specific code for accessing the orchestrator
@@ -12,7 +13,7 @@ module PeEventForwarding
 
     def get_jobs(limit: 500, offset: 0, order: 'desc', order_by: 'name', index_count: nil, new_jobs: nil, timeout: nil)
       params = {
-        limit:    limit,
+        limit:    [new_jobs, limit].min,
         offset:   offset,
         order:    order,
         order_by: order_by,
@@ -25,7 +26,7 @@ module PeEventForwarding
       loop do
         response       = pe_client.pe_get_request('orchestrator/v1/jobs', params, timeout)
         response_body  = JSON.parse(response.body)
-        response_body['items']&.map { |item| response_items << item }
+        response_body['items']&.each { |item| response_items << item }
 
         job_counter += response_body['items'].empty? ? 0 : response_body['items'].count
         break if job_counter >= new_jobs
@@ -36,7 +37,7 @@ module PeEventForwarding
                            new_jobs - job_counter
                          end
       end
-      log.debug("PE Get Jobs Items Found: #{response_items.count}")
+      log&.debug("PE Get Jobs Items Found: #{response_items.count}")
       raise 'Orchestrator API request failed' unless response.code == '200'
       { 'api_total_count' => total_count, 'events' => response_items }
     end
@@ -64,6 +65,83 @@ module PeEventForwarding
       JSON.parse(response.body)
     end
 
+    def plan_job_finished_timestamp(job)
+      job['finished_timestamp']
+    end
+
+    def parse_timestamp(ts)
+      return nil if ts.nil?
+      # Prefer numeric values when possible (e.g. "123.456" -> 123.456).
+      begin
+        Float(ts)
+      rescue StandardError
+        begin
+          Time.parse(ts).to_f
+        rescue StandardError
+          # Fallback to numeric conversion
+          ts.to_f
+        end
+      end
+    end
+
+    # Fetch plan_jobs using finish timestamp filtering. Returns hash with
+    # 'api_total_count' set to the max finished_timestamp seen and 'events' array.
+    def get_plan_jobs_since(min_finish_timestamp:, limit: 500, offset: 0, timeout: nil)
+      params = {
+        limit:    limit,
+        offset:   offset,
+        order:    'asc',
+      }
+      params[:min_finish_timestamp] = min_finish_timestamp unless min_finish_timestamp.nil? || min_finish_timestamp.to_s.empty?
+
+      response_items = []
+      response = ''
+      loop do
+        response = pe_client.pe_get_request('orchestrator/v1/plan_jobs', params, timeout)
+        response_body = JSON.parse(response.body)
+        items = response_body['items'] || []
+        response_items.concat(items)
+        break if items.empty?
+        params[:offset] = params[:offset] + items.count
+      end
+      raise 'Orchestrator API request failed' unless response.code == '200'
+      # Filter to only finished jobs and compute max finished timestamp
+      finished = response_items.select { |j| plan_job_finished_timestamp(j) }
+      max_ts = finished.map { |j| plan_job_finished_timestamp(j) }.compact.max
+      { 'last_finished' => max_ts, 'events' => finished }
+    end
+
+    def new_plan_data_by_finish(last_finished, timeout, processed_ids: [])
+      res = get_plan_jobs_since(min_finish_timestamp: last_finished, timeout: timeout)
+      events = res['events'] || []
+      # If there are no finished events at or after the timestamp, nothing to do
+      if events.empty?
+        log&.debug('New Job Count: Orchestrator Plan: data is current')
+        return nil
+      end
+
+      # Filter out already-processed job ids that match the inclusive last_finished timestamp
+      if processed_ids.any?
+        events.reject! do |j|
+          ts = plan_job_finished_timestamp(j)
+          ts.to_s == last_finished.to_s && processed_ids.include?(j['name'].to_s)
+        end
+      end
+
+      # After filtering, if no events remain, nothing new
+      if events.empty?
+        log&.debug('New Job Count: Orchestrator Plan: data is current after dedupe')
+        return nil
+      end
+
+      # Sort by finished timestamp ascending so processors get events in time order
+      events.sort_by! { |j| parse_timestamp(plan_job_finished_timestamp(j)) || 0 }
+
+      max_ts = events.map { |j| plan_job_finished_timestamp(j) }.compact.max
+      log&.debug("New Plan Jobs Found: #{events.count}")
+      { 'last_finished' => max_ts, 'events' => events }
+    end
+
     def self.get_id_from_response(response)
       res = PeEventForwarding::Http.response_to_hash(response)
       res['job']['name']
@@ -85,10 +163,10 @@ module PeEventForwarding
     def new_data(last_count, timeout)
       new_job_count = current_job_count(timeout) - last_count
       if new_job_count.zero? || new_job_count.negative?
-        log.debug('New Job Count: Orchestrator: data is current')
+        log&.debug('New Job Count: Orchestrator: data is current')
         nil
       else
-        log.debug("New Job Count: Orchestrator: #{new_job_count}")
+        log&.debug("New Job Count: Orchestrator: #{new_job_count}")
         get_jobs(index_count: last_count, new_jobs: new_job_count, timeout: timeout)
       end
     end

--- a/files/collect_api_events.rb
+++ b/files/collect_api_events.rb
@@ -8,6 +8,7 @@ require_relative 'util/lockfile'
 require_relative 'util/http'
 require_relative 'util/pe_http'
 require_relative 'util/index'
+require_relative 'util/plan_index'
 require_relative 'util/processor'
 require_relative 'util/logger'
 
@@ -35,6 +36,7 @@ def main(confdir, logpath, lockdir)
     log.error('Lockfile creation failed.')
   end
   index = PeEventForwarding::Index.new(confdir)
+  plan_index = PeEventForwarding::PlanIndex.new(confdir)
   data = {}
 
   client_options = {
@@ -50,7 +52,7 @@ def main(confdir, logpath, lockdir)
   orchestrator = PeEventForwarding::Orchestrator.new(settings['pe_console'], **client_options)
   activities = PeEventForwarding::Activity.new(settings['pe_console'], **client_options)
 
-  service_names = if !settings['skip_events'].nil?
+  service_names = if settings['skip_events']
                     PeEventForwarding::Activity::SERVICE_NAMES.reject do |service|
                       settings['skip_events'].include?(service.to_s)
                     end
@@ -59,13 +61,24 @@ def main(confdir, logpath, lockdir)
                   end
 
   if index.first_run?
-    if settings['skip_jobs'].nil?
+    if settings['skip_jobs']
+      data[:orchestrator] = -1
+    else
       log.debug("Starting orchestrator for first run with #{index.count(:orchestrator)} event(s)")
       data[:orchestrator] = orchestrator.current_job_count(timeout)
+    end
+    unless settings['skip_plans']
+      log.debug('Starting orchestrator plan_jobs for first run')
+      # Index the checkpoint as Time.now with no processed IDs. Any plan finishing
+      # strictly after this point will be collected on the next run.
+      plan_index.save(last_finished: Time.now.utc.iso8601, ids: [])
     end
     service_names.each do |service|
       log.debug("Starting #{service} for first run with #{index.count(service)} event(s)")
       data[service] = activities.current_event_count(service, timeout)
+    end
+    settings['skip_events']&.each do |service|
+      data[service.to_sym] = -1
     end
     index.save(**data)
     log.debug("First run. Recorded event count in #{index.filepath} and now exiting.")
@@ -79,23 +92,6 @@ def main(confdir, logpath, lockdir)
   # that have accumulated in the interim.
   settings['skip_events']&.each do |service|
     data[service.to_sym] = -1
-  end
-
-  if settings['skip_jobs']
-    data[:orchestrator] = -1
-  elsif settings['skip_jobs'].nil? && index.count(:orchestrator) == -1
-    # At this point we know orchestrator is newly re-enabled.
-    # Reinitialize the orchestrator event count and exit.
-    # Next run will continue as usual.
-    data[:orchestrator] = orchestrator.current_job_count(timeout)
-    index.save(**data)
-    log.debug("Orchestration jobs collection reenabled. First run. Recorded event count in #{index.filepath}.")
-    # The index is now saved, so to ensure that the count does not get passed to any
-    # processors (which should be written to check for `nil` or `-1`) we set it to nil.
-    data[:orchestrator] = nil
-  else
-    log.debug("Orchestrator: Starting count: #{index.count(:orchestrator)}")
-    data[:orchestrator] = orchestrator.new_data(index.count(:orchestrator), timeout)
   end
 
   service_names.each do |service|
@@ -115,17 +111,61 @@ def main(confdir, logpath, lockdir)
     end
   end
 
-  combined_keys = if settings['skip_jobs'].nil?
-                    service_names.dup << :orchestrator
-                  else
-                    service_names.dup
-                  end
-  events_counts = {}
-  combined_keys.map do |key|
-    events_counts[key] = data[key].count unless data[key].nil? || data[key].is_a?(Integer)
+  if settings['skip_jobs']
+    data[:orchestrator] = -1
+  elsif index.count(:orchestrator) == -1
+    # At this point we know orchestrator is newly re-enabled.
+    # Reinitialize the orchestrator event count and exit.
+    # Next run will continue as usual.
+    data[:orchestrator] = orchestrator.current_job_count(timeout)
+    index.save(**data)
+    log.debug("Orchestration jobs collection reenabled. First run. Recorded event count in #{index.filepath}.")
+    # The index is now saved, so to ensure that the count does not get passed to any
+    # processors (which should be written to check for `nil` or `-1`) we set it to nil.
+    data[:orchestrator] = nil
+  else
+    log.debug("Orchestrator: Starting count: #{index.count(:orchestrator)}")
+    data[:orchestrator] = orchestrator.new_data(index.count(:orchestrator), timeout)
   end
 
-  if data.any? { |_k, v| !v.nil? || (v != -1) }
+  if settings['skip_plans']
+    # plans are explicitly disabled via settings; mark plan index accordingly
+    plan_index.save(last_finished: nil, ids: [])
+  elsif plan_index.last_finished.nil?
+    # Re-enable plan collection. Index the checkpoint as Time.now with no processed IDs.
+    # Only plans finishing after this moment will be collected — mirrors the task
+    # re-enable pattern which snapshots the current count and moves on.
+    plan_index.save(last_finished: Time.now.utc.iso8601, ids: [])
+    log.debug("Orchestration plan_jobs collection reenabled. Recorded plan checkpoint in #{plan_index.filepath}.")
+  else
+    log.debug("Orchestrator plan_jobs: Indexing last finished timestamp: #{plan_index.last_finished}")
+    processed_ids = plan_index.ids
+    processed_ids = [] unless processed_ids.is_a?(Array)
+    res = orchestrator.new_plan_data_by_finish(plan_index.last_finished, timeout, processed_ids: processed_ids)
+    unless res.nil?
+      # res contains 'last_finished' => max finished timestamp, and 'events' => [jobs]
+      data[:orchestrator_plan] = res
+      # compute ids of jobs that have the max finished timestamp so we can dedupe inclusive queries
+      max_ts = res['last_finished']
+      finished_jobs = (res['events'] || []).select do |j|
+        orchestrator.plan_job_finished_timestamp(j).to_s == max_ts.to_s
+      end
+      processed_ids = finished_jobs.map { |j| j['name'].to_s }
+      # persist plan index (advance last_finished and ids)
+      plan_index.save(last_finished: max_ts, ids: processed_ids)
+    end
+  end
+
+  combined_keys = service_names.dup
+  combined_keys << :orchestrator unless settings['skip_jobs']
+  combined_keys << :orchestrator_plan if data.key?(:orchestrator_plan)
+  events_counts = {}
+  combined_keys.each do |key|
+    events_counts[key] = data[key]['events'].count if data[key].is_a?(Hash) && data[key]['events'].is_a?(Array)
+    events_counts[key] = data[key].count if data[key].is_a?(Array)
+  end
+
+  if data.any? { |_k, v| !v.nil? && v != -1 }
     PeEventForwarding::Processor.find_each("#{confdir}/processors.d") do |processor|
       log.info("#{processor.name} starting with events: #{events_counts}")
       start_time = Time.now
@@ -135,7 +175,7 @@ def main(confdir, logpath, lockdir)
       log.warn(processor.stderr, source: processor.name, exit_code: processor.exitcode) unless processor.stderr.empty? && processor.exitcode == 0
       log.info("#{processor.name} finished: #{duration} second(s) to complete.")
     end
-    index.save(**data)
+    index.save(**data.reject { |k, _| k == :orchestrator_plan })
   end
   log.info("Event Forwarding total execution time: #{Time.now - common_event_start_time} second(s)")
 rescue => exception

--- a/files/collect_api_events.rb
+++ b/files/collect_api_events.rb
@@ -175,8 +175,8 @@ def main(confdir, logpath, lockdir)
       log.warn(processor.stderr, source: processor.name, exit_code: processor.exitcode) unless processor.stderr.empty? && processor.exitcode == 0
       log.info("#{processor.name} finished: #{duration} second(s) to complete.")
     end
-    index.save(**data.reject { |k, _| k == :orchestrator_plan })
   end
+  index.save(**data.reject { |k, _| k == :orchestrator_plan }) if data.any? { |_k, v| !v.nil? }
   log.info("Event Forwarding total execution time: #{Time.now - common_event_start_time} second(s)")
 rescue => exception
   puts exception

--- a/files/util/http.rb
+++ b/files/util/http.rb
@@ -43,7 +43,7 @@ module PeEventForwarding
       http.request(request)
     end
 
-    # post_request takes a uri(string), headers(optional(hash)), and a timeout(optional(int)).
+    # get_request takes a uri(string), headers(optional(hash)), and a timeout(optional(int)).
     # Basic auth will be used if provided.
     def get_request(uri, timeout, headers = {})
       headers['Content-Type'] = 'application/json' unless headers.key? 'Content-Type'
@@ -54,7 +54,7 @@ module PeEventForwarding
         url.port,
         use_ssl: url.scheme == 'https',
         verify_mode: verify_mode,
-        ca_cert: ca_cert_path,
+        ca_file: ca_cert_path,
         read_timeout:    timeout.to_i,
         connect_timeout: timeout.to_i,
         ssl_timeout:     timeout.to_i,

--- a/files/util/index.rb
+++ b/files/util/index.rb
@@ -50,7 +50,11 @@ module PeEventForwarding
       data = counts(refresh: true)
       service.each do |key, value|
         next if value.nil?
-        data[key] = value.is_a?(Integer) ? value : value['api_total_count']
+        data[key] = if value.is_a?(Hash)
+                      value['api_total_count']
+                    else
+                      value
+                    end
       end
       File.write(filepath, data.to_yaml)
       @counts = data

--- a/files/util/plan_index.rb
+++ b/files/util/plan_index.rb
@@ -1,0 +1,39 @@
+module PeEventForwarding
+  # Simple tracker for plan job finished-timestamp and processed ids
+  class PlanIndex
+    attr_accessor :filepath
+
+    def initialize(statedir)
+      require 'yaml'
+      @filepath = "#{statedir}/pe_event_forwarding_plan_index.yaml"
+      if File.exist? @filepath
+        @data = YAML.safe_load(File.read(@filepath), permitted_classes: [Symbol]) || {}
+      else
+        new_index_file
+      end
+    end
+
+    def new_index_file
+      @data = {
+        'last_finished' => nil,
+        'ids_at_last_finished' => [],
+      }
+      File.write(filepath, @data.to_yaml)
+    end
+
+    def last_finished
+      # nil means disabled / not set
+      @data.key?('last_finished') ? @data['last_finished'] : nil
+    end
+
+    def ids
+      @data['ids_at_last_finished'] || []
+    end
+
+    def save(last_finished:, ids: [])
+      @data['last_finished'] = last_finished
+      @data['ids_at_last_finished'] = ids
+      File.write(filepath, @data.to_yaml)
+    end
+  end
+end

--- a/files/util/processor.rb
+++ b/files/util/processor.rb
@@ -22,12 +22,10 @@ module PeEventForwarding
     end
 
     def self.find_each(dir)
-      return [] unless File.exist? dir
-      dir_listing(dir).select do |path|
-        unless FileTest.directory?(path)
-          processor = PeEventForwarding::Processor.new(path)
-          block_given? ? yield(processor) : processor
-        end
+      return unless File.exist? dir
+      dir_listing(dir).each do |path|
+        next if FileTest.directory?(path)
+        yield PeEventForwarding::Processor.new(path)
       end
     end
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -50,6 +50,8 @@
 #   When set to `undef` the default of 60 seconds will be used
 # @param [Optional[Boolean]] skip_jobs
 #   When true, event collection from the Orchestrator API is disabled.
+# @param [Optional[Boolean]] skip_plans
+#   When true, event collection from the Orchestrator plan_jobs API is disabled.
 # @param [Optional[Array]] skip_events
 #   Array of event types that should be skipped during event collection from the Activity API.
 #   Acceptable values are: ['classifier','code-manager','pe-console','rbac']
@@ -72,6 +74,7 @@ class pe_event_forwarding (
   Optional[Integer]                               $api_page_size = undef,
   Optional[Integer]                               $timeout       = undef,
   Optional[Boolean]                               $skip_jobs     = undef,
+  Optional[Boolean]                               $skip_plans    = undef,
   Optional[Array[Enum[
         'classifier',
         'code-manager',

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-pe_event_forwarding",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "author": "Puppet, Inc.",
   "summary": "A module that contains support for integration event reporting",
   "license": "Apache-2.0",
@@ -24,22 +24,22 @@
     {
       "operatingsystem": "AmazonLinux",
       "operatingsystemrelease": [
-        "2"
+        "2",
+        "2023"
       ]
     },
     {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
-        "7",
         "8"
       ]
     },
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "7",
         "8",
-        "9"
+        "9",
+        "10"
       ]
     },
     {
@@ -59,9 +59,9 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "18.04",
         "20.04",
-        "22.04"
+        "22.04",
+        "24.04"
       ]
     }
   ],
@@ -71,7 +71,7 @@
       "version_requirement": ">= 7.8.0 < 9.0.0"
     }
   ],
-  "pdk-version": "3.3.0",
-  "template-url": "pdk-default#3.3.0",
+  "pdk-version": "3.4.0",
+  "template-url": "https://github.com/puppetlabs/pdk-templates#3.3.0",
   "template-ref": "tags/3.3.0-0-g5d17ec1"
 }

--- a/metadata.json
+++ b/metadata.json
@@ -43,7 +43,7 @@
       ]
     },
     {
-      "operatingsystem": "RockyLinux",
+      "operatingsystem": "Rocky",
       "operatingsystemrelease": [
         "8",
         "9"
@@ -68,7 +68,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 7.8.0 < 9.0.0"
+      "version_requirement": ">= 8.2.0 < 9.0.0"
     }
   ],
   "pdk-version": "3.4.0",

--- a/plans/acceptance/pe_server.pp
+++ b/plans/acceptance/pe_server.pp
@@ -10,32 +10,49 @@
 # @param pe_settings
 #   Hash with key `password` and value of PE console password for admin user
 plan pe_event_forwarding::acceptance::pe_server(
-  Optional[String] $version = '2023.8.0',
-  Optional[Hash] $pe_settings = { password => 'puppetlabsPi3!', configure_tuning => false }
+  Optional[String] $version     = '2023.8.5',
+  Optional[Hash]   $pe_settings = { password => 'puppetlabsPi3!', configure_tuning => false }
 ) {
   # machines are not yet ready at time of installing the puppetserver, so we wait 30s
-  $localhost = get_targets('localhost')
-  run_command('sleep 30s', $localhost)
+  ctrl::sleep(30)
 
-  #identify pe server node
+  # identify pe server nodes
   $puppet_server = get_targets('*').filter |$n| { $n.vars['role'] == 'server' }
 
-  # extract pe version from matrix_from_metadata_v3 output
-  $ent_version = regsubst($version, '-puppet_enterprise', '')
+  # extract pe version from matrix_from_metadata_v3 output (e.g. 2023.8.0-puppet_enterprise -> 2023.8.0)
+  $pe_version = regsubst($version, '-puppet_enterprise', '')
 
-  # install pe server
-  run_plan(
-    'deploy_pe::provision_master',
-    $puppet_server,
-    'version' => $ent_version,
-    'pe_settings' => $pe_settings
-  )
+  # install PE on each server in parallel
+  $futures = $puppet_server.map |$server| {
+    background("set up PE on ${server.name}") || {
+      # derive platform from inventory facts populated by the provisioner
+      $platform = $server.facts['platform']
 
-  $cmd = @("CMD")
-    echo 'puppetlabsPi3!' | puppet access login --lifetime 1y --username admin
-    puppet infrastructure tune | sed "s,\\x1B\\[[0-9;]*[a-zA-Z],,g" > /etc/puppetlabs/code/environments/production/data/common.yaml
-    puppet agent -t
-    | CMD
+      $platform_tag = case $platform {
+        /rhel-(\d+)/:          { "el-${1}-x86_64" }
+        /redhat-(\d+)/:        { "el-${1}-x86_64" }
+        /almalinux-(\d+)/:     { "el-${1}-x86_64" }
+        /rocky-linux-(\d+)/:   { "el-${1}-x86_64" }
+        /ubuntu-(\d\d)(\d\d)/: { "ubuntu-${1}.${2}-amd64" }
+        /sles-(\d+)/:          { "sles-${1}-x86_64" }
+        default: { fail("Unknown platform for PE install: ${platform}") }
+      }
 
-  run_command($cmd, $puppet_server, '_catch_errors' => true)
+      $installer_url = "https://pm.puppetlabs.com/puppet-enterprise/${pe_version}/puppet-enterprise-${pe_version}-${platform_tag}.tar.gz"
+
+      # install PE via direct tarball download — ~5min faster than using deploy_pe
+      run_task(
+        'pe_event_forwarding::install_pe',
+        $server,
+        url              => $installer_url,
+        console_password => $pe_settings['password'],
+      )
+
+      run_command('puppet agent -t', $server, '_catch_errors' => true)
+
+      # create the RBAC token for integration testing
+      run_command("echo '${pe_settings['password']}' | puppet access login --username admin --lifetime 12h", $server)
+    }
+  }
+  wait($futures)
 }

--- a/plans/acceptance/provision_machines.pp
+++ b/plans/acceptance/provision_machines.pp
@@ -6,7 +6,7 @@
 #   os image
 plan pe_event_forwarding::acceptance::provision_machines(
   Optional[String] $using = 'abs',
-  Optional[String] $image = 'centos-7-x86_64'
+  Optional[String] $image = 'redhat-8-x86_64'
 ) {
   # provision machines, set roles
   run_task("provision::${using}", 'localhost', action => 'provision', platform => $image, vars => 'role: server')

--- a/provision.yaml
+++ b/provision.yaml
@@ -1,15 +1,5 @@
 acceptance:
   provisioner: abs
-  images: ['centos-7-x86_64']
+  images: ['redhat-8-x86_64', 'ubuntu-2404-x86_64']
   vars: |
     role: server
-master:
-  provisioner: abs
-  images: ['centos-7-x86_64']
-  vars: |
-    role: server
-agent:
-  provisioner: abs
-  images: ['centos-7-x86_64']
-  vars: |
-    role: agent

--- a/rakelib/helpers.rake
+++ b/rakelib/helpers.rake
@@ -1,123 +1,104 @@
-require_relative '../spec/support/acceptance/helpers'
-
-include TargetHelpers
-
-def servicenow_params(args)
-  args.names.map do |name|
-    args[name] || ENV[name.to_s.upcase]
-  end
-end
-
-# Executes a command locally.
-#
-# @param command [String] command to execute.
-# @return [Object] the standard out stream.
-def run_local_command(command)
-  stdout, stderr, status = Open3.capture3(command)
-  error_message = "Attempted to run\ncommand:'#{command}'\nstdout:#{stdout}\nstderr:#{stderr}"
-  raise error_message unless status.to_i.zero?
-
-  stdout
-end
-
-def task_prefix(hostname)
-  "bundle exec bolt task run --modulepath spec/fixtures/modules --target #{hostname}"
-end
-
 namespace :acceptance do
-  desc 'Upload Test Processors'
-  task :upload_processors do
-    ['proc1.sh', 'proc2.rb'].each do |processor|
-      proc_path = "spec/support/acceptance/processors/#{processor}"
-      folder = '/etc/puppetlabs/puppet/pe_event_forwarding/processors.d'
-      puppetserver.run_shell("mkdir -p #{folder}")
-      puppetserver.bolt_upload_file(proc_path, folder)
-      puppetserver.run_shell("chmod +x #{folder}/#{processor}")
-    end
-  end
+  require_relative '../spec/support/acceptance/helpers'
+  include TargetHelpers
 
   desc 'Provisions the VMs. This is currently just the server'
   task :provision_vms do
-    if File.exist?('../spec/fixtures/litmus_inventory.yaml')
-      # Check if a server VM's already been setup
+    if File.exist?('spec/fixtures/litmus_inventory.yaml')
       begin
-        uri = puppetserver.uri
+        uri = puppetserver.first.uri
         puts("A server VM at '#{uri}' has already been set up")
         next
       rescue TargetNotFoundError
-        puts 'Server VM not yet set up.' # Pass-thru, this means that we haven't set up the server VM
+        puts 'Server VM not yet set up.'
       end
     end
 
     provision_list = ENV['PROVISION_LIST'] || 'acceptance'
     Rake::Task['litmus:provision_list'].invoke(provision_list)
-    Rake::Task['acceptance:add_localhost_target'].invoke
   end
 
-  desc 'Add localhost target to inventory file'
-  task :add_localhost_target do
-    inventory = inventory_hash_from_inventory_file
-    localhost_group = localhost_inventory_hash['groups'][0]
-    localhost_group['targets'][0]['vars'] = {'role' => 'localhost'}
-    inventory['groups'] << localhost_group
-    write_to_inventory_file(inventory, 'spec/fixtures/litmus_inventory.yaml')
-  end
-
-  # TODO: This should be refactored to use the https://github.com/puppetlabs/puppetlabs-peadm
-  # module for PE setup
   desc 'Sets up PE on the server'
   task :setup_pe do
     include ::BoltSpec::Run
     inventory_hash = inventory_hash_from_inventory_file
-    target_nodes = find_targets(inventory_hash, 'ssh_nodes')
 
     config = { 'modulepath' => File.join(Dir.pwd, 'spec', 'fixtures', 'modules') }
+    params = {}
+    params[:version] = ENV['PE_VERSION'] if ENV['PE_VERSION']
 
-    bolt_result = run_plan('pe_event_forwarding::acceptance::pe_server', {}, config: config, inventory: inventory_hash.clone)
+    bolt_result = run_plan('pe_event_forwarding::acceptance::pe_server', params, config: config, inventory: inventory_hash.clone)
+    raise "setup_pe failed:\n#{JSON.pretty_generate(bolt_result)}" if bolt_result['status'] == 'failure'
   end
 
   desc 'Installs the module on the server'
   task :install_module do
-    Rake::Task['litmus:install_module'].invoke(puppetserver.uri)
+    puppetserver.each do |server|
+      Rake::Task['litmus:install_module'].reenable
+      Rake::Task['litmus:install_module'].invoke(server.uri)
+    end
   end
 
-  desc 'Reloads puppetserver on the server'
-  task :reload_module do
-    result = puppetserver.run_shell('/opt/puppetlabs/bin/puppetserver reload').stdout.chomp
-    puts "Error: #{result}" unless result == ''
-  end
-
-  desc 'Gets the puppetserver logs for service now'
-  task :get_logs do
-    puts puppetserver.run_shell('tail -500 /var/log/puppetlabs/puppetserver/puppetserver.log').stdout.chomp
+  desc 'Upload test processors'
+  task :upload_processors do
+    puppetserver.each do |server|
+      ['proc1.sh', 'proc2.rb'].each do |processor|
+        proc_path = "spec/support/acceptance/processors/#{processor}"
+        folder = '/etc/puppetlabs/puppet/pe_event_forwarding/processors.d'
+        server.run_shell("mkdir -p #{folder}")
+        server.bolt_upload_file(proc_path, folder)
+        server.run_shell("chmod +x #{folder}/#{processor}")
+      end
+    end
   end
 
   desc 'Do an agent run'
   task :agent_run do
-    puts puppetserver.run_shell('puppet agent -t').stdout.chomp
+    puppetserver.each { |server| puts server.run_shell('puppet agent -t').stdout.chomp }
   end
 
-  desc 'Runs the tests'
+  desc 'Runs the tests from the local machine or CI runner'
   task :run_tests do
     rspec_command  = 'bundle exec rspec ./spec/acceptance --format documentation'
+    rspec_command += ' --format RspecJunitFormatter --out rspec_junit_results.xml' if ENV['CLOUD_CI'] == 'true'
     puts("Running the tests ...\n")
     unless system(rspec_command)
-      # system returned false which means rspec failed. So exit 1 here
       exit 1
+    end
+  end
+
+  desc 'Task to run rspec tests against multiple targets'
+  task :ci_run_tests do
+    include ::BoltSpec::Run
+    config = { 'modulepath' => File.join(Dir.pwd, 'spec', 'fixtures', 'modules') }
+
+    puppetserver.each do |server|
+      message = "Running rspec tests against #{server.uri} !"
+      spec_spinner = start_spinner(message)
+      params = { 'sut' => server.uri, 'format' => 'documentation' }
+      bolt_result = run_task('provision::run_tests', 'localhost', params, config: config)
+      stop_spinner(spec_spinner)
+      if bolt_result[0]['value'].has_key?('_error')
+        test_result = bolt_result[0]['value']['_error']['msg'].to_json
+        puts JSON.parse(test_result)
+        exit 1
+      else
+        test_result = bolt_result[0]['value']['result'].to_json
+        puts JSON.parse(test_result)
+      end
     end
   end
 
   desc 'Set up the test infrastructure'
   task :setup do
     tasks = [
-      :provision_vms,
-      :setup_pe,
-      :add_localhost_target,
-      :install_module,
+      'spec_prep',
+      'acceptance:provision_vms',
+      'acceptance:setup_pe',
+      'acceptance:install_module',
     ]
 
     tasks.each do |task|
-      task = "acceptance:#{task}"
       puts("Invoking #{task}")
       Rake::Task[task].invoke
       puts("\n")
@@ -127,14 +108,15 @@ namespace :acceptance do
   desc 'Teardown the setup'
   task :tear_down do
     puts("Tearing down the test infrastructure ...\n")
-    Rake::Task['litmus:tear_down'].invoke(puppetserver.uri)
+    Rake::Task['litmus:tear_down'].invoke
+    FileUtils.rm_f('spec/fixtures/litmus_inventory.yaml')
   end
 
-  desc 'Task for CI'
-  task :ci_run_tests do
+  desc 'Full CI pipeline: setup, run tests, tear down'
+  task :ci_tests do
     begin
       Rake::Task['acceptance:setup'].invoke
-      Rake::Task['acceptance:run_tests'].invoke
+      Rake::Task['acceptance:ci_run_tests'].invoke
     ensure
       Rake::Task['acceptance:tear_down'].invoke
     end

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -4,61 +4,61 @@ require 'spec_helper_acceptance'
 describe 'Verify the minimum install' do
   before(:all) do
     set_sitepp_content(declare('class', 'pe_event_forwarding', { 'pe_token' => auth_token }.merge(cron_schedule)))
-    trigger_puppet_run(puppetserver)
+    trigger_puppet_run(TARGET_SERVER)
   end
 
   after(:all) do
     set_sitepp_content(declare('class', 'pe_event_forwarding', { 'pe_token' => auth_token, 'disabled' => true, 'log_level' => 'DEBUG' }))
-    trigger_puppet_run(puppetserver)
+    trigger_puppet_run(TARGET_SERVER)
   end
 
   describe 'places files correctly' do
     it 'api class folder' do
       directory = "#{CONFDIR}/pe_event_forwarding/api"
-      expect(puppetserver.directory_exists?(directory)).to be true
+      expect(TARGET_SERVER.directory_exists?(directory)).to be true
     end
 
     it 'util class folder' do
       directory = "#{CONFDIR}/pe_event_forwarding/util"
-      expect(puppetserver.directory_exists?(directory)).to be true
+      expect(TARGET_SERVER.directory_exists?(directory)).to be true
     end
 
     it 'collection_settings.yaml' do
       yaml_file = "#{CONFDIR}/pe_event_forwarding/collection_settings.yaml"
-      expect(puppetserver.file_exists?(yaml_file)).to be true
+      expect(TARGET_SERVER.file_exists?(yaml_file)).to be true
     end
 
     it 'collection_secrets.yaml' do
       yaml_file = "#{CONFDIR}/pe_event_forwarding/collection_secrets.yaml"
-      expect(puppetserver.file_exists?(yaml_file)).to be true
+      expect(TARGET_SERVER.file_exists?(yaml_file)).to be true
     end
 
     it 'collect_api_events.rb' do
       script_file = "#{CONFDIR}/pe_event_forwarding/collect_api_events.rb"
-      expect(puppetserver.file_exists?(script_file)).to be true
+      expect(TARGET_SERVER.file_exists?(script_file)).to be true
     end
 
     it 'processors.d folder' do
       script_file = "#{CONFDIR}/pe_event_forwarding/processors.d"
-      expect(puppetserver.directory_exists?(script_file)).to be true
+      expect(TARGET_SERVER.directory_exists?(script_file)).to be true
     end
   end
 
   describe 'it removes old settings file' do
     it 'events_collection.yaml' do
       yaml_file = "#{CONFDIR}/pe_event_forwarding/events_collection.yaml"
-      expect(puppetserver.file_exists?(yaml_file)).to be false
+      expect(TARGET_SERVER.file_exists?(yaml_file)).to be false
     end
   end
 
   describe 'configures cron' do
     it 'enables cron' do
-      result = puppetserver.run_shell('crontab -u pe-puppet -l', expect_failures: true).stdout
+      result = TARGET_SERVER.run_shell('crontab -u pe-puppet -l', expect_failures: true).stdout
       expect(result.include?('collect_api_events.rb')).to be true
     end
 
     it 'applies the correct schedule' do
-      result = puppetserver.run_shell('crontab -u pe-puppet -l', expect_failures: true).stdout
+      result = TARGET_SERVER.run_shell('crontab -u pe-puppet -l', expect_failures: true).stdout
       expect(result.include?('10 9 6 7 3')).to be true
     end
   end

--- a/spec/acceptance/index_spec.rb
+++ b/spec/acceptance/index_spec.rb
@@ -3,15 +3,15 @@ require 'yaml'
 
 describe 'index file' do
   before(:all) do
-    puppetserver.run_shell("#{CONFDIR}/pe_event_forwarding/collect_api_events.rb")
+    TARGET_SERVER.run_shell("#{CONFDIR}/pe_event_forwarding/collect_api_events.rb")
   end
 
   it 'index file exists' do
-    expect(puppetserver.file_exists?("#{CONFDIR}/pe_event_forwarding/pe_event_forwarding_indexes.yaml")).to be true
+    expect(TARGET_SERVER.file_exists?("#{CONFDIR}/pe_event_forwarding/pe_event_forwarding_indexes.yaml")).to be true
   end
 
   it 'writes expected keys' do
-    index_contents = puppetserver.run_shell("cat #{CONFDIR}/pe_event_forwarding/pe_event_forwarding_indexes.yaml").stdout
+    index_contents = TARGET_SERVER.run_shell("cat #{CONFDIR}/pe_event_forwarding/pe_event_forwarding_indexes.yaml").stdout
     index = YAML.safe_load(index_contents, permitted_classes: [Symbol])
     [:classifier, :rbac, :'pe-console', :'code-manager', :orchestrator].each do |key|
       expect(index.keys.include?(key)).to be true
@@ -20,16 +20,16 @@ describe 'index file' do
 
   it 'treats run as the first when first_run failed' do
     index_fail_reset
-    first_run_count = puppetserver.run_shell("grep 'first run' #{LOGDIR}/pe_event_forwarding.log -c", expect_failures: true).stdout.to_i
+    first_run_count = TARGET_SERVER.run_shell("grep 'first run' #{LOGDIR}/pe_event_forwarding.log -c", expect_failures: true).stdout.to_i
     expect(first_run_count).to eq(7)
   end
 
   it 'updates orchestrator index value' do
-    index_contents = puppetserver.run_shell("cat #{CONFDIR}/pe_event_forwarding/pe_event_forwarding_indexes.yaml").stdout
+    index_contents = TARGET_SERVER.run_shell("cat #{CONFDIR}/pe_event_forwarding/pe_event_forwarding_indexes.yaml").stdout
     index          = YAML.safe_load(index_contents, permitted_classes: [Symbol])
     current_value  = index[:orchestrator]
-    puppetserver.run_shell("LC_ALL=en_US.UTF-8 puppet task run facts --nodes #{console_host_fqdn}")
-    index_contents = puppetserver.run_shell("#{CONFDIR}/pe_event_forwarding/collect_api_events.rb ; cat #{CONFDIR}/pe_event_forwarding/pe_event_forwarding_indexes.yaml").stdout
+    TARGET_SERVER.run_shell("LC_ALL=en_US.UTF-8 puppet task run facts --nodes #{console_host_fqdn}")
+    index_contents = TARGET_SERVER.run_shell("#{CONFDIR}/pe_event_forwarding/collect_api_events.rb ; cat #{CONFDIR}/pe_event_forwarding/pe_event_forwarding_indexes.yaml").stdout
     index = YAML.safe_load(index_contents, permitted_classes: [Symbol])
     updated_value = index[:orchestrator]
     expect(updated_value).to eql(current_value + 1)
@@ -38,16 +38,16 @@ describe 'index file' do
   it 'when skip_events is undefined (default), rbac index updates' do
     current_value = get_service_index(:rbac)
     upload_rbac_script
-    puppetserver.run_shell("#{CONFDIR}/pe_event_forwarding/generate_rbac_event.rb --create")
-    puppetserver.run_shell("#{CONFDIR}/pe_event_forwarding/collect_api_events.rb")
+    TARGET_SERVER.run_shell("#{CONFDIR}/pe_event_forwarding/generate_rbac_event.rb --create")
+    TARGET_SERVER.run_shell("#{CONFDIR}/pe_event_forwarding/collect_api_events.rb")
     updated_value = get_service_index(:rbac)
     expect(updated_value).to eql(current_value + 1)
   end
 
   it 'when skip_events includes rbac, index does NOT update' do
     disable_rbac_events
-    puppetserver.run_shell("#{CONFDIR}/pe_event_forwarding/generate_rbac_event.rb --update")
-    puppetserver.run_shell("#{CONFDIR}/pe_event_forwarding/collect_api_events.rb")
+    TARGET_SERVER.run_shell("#{CONFDIR}/pe_event_forwarding/generate_rbac_event.rb --update")
+    TARGET_SERVER.run_shell("#{CONFDIR}/pe_event_forwarding/collect_api_events.rb")
     updated_value = get_service_index(:rbac)
     expect(updated_value).to be(-1)
   end
@@ -56,10 +56,10 @@ describe 'index file' do
     enable_rbac_events
     original_rbac_index = get_service_index(:rbac)
     disable_rbac_events
-    puppetserver.run_shell("#{CONFDIR}/pe_event_forwarding/generate_rbac_event.rb --update --email pie-team@example.com")
-    puppetserver.run_shell("#{CONFDIR}/pe_event_forwarding/collect_api_events.rb")
+    TARGET_SERVER.run_shell("#{CONFDIR}/pe_event_forwarding/generate_rbac_event.rb --update --email pie-team@example.com")
+    TARGET_SERVER.run_shell("#{CONFDIR}/pe_event_forwarding/collect_api_events.rb")
     enable_rbac_events
-    puppetserver.run_shell("#{CONFDIR}/pe_event_forwarding/collect_api_events.rb")
+    TARGET_SERVER.run_shell("#{CONFDIR}/pe_event_forwarding/collect_api_events.rb")
     updated_rbac_index = get_service_index(:rbac)
     expect(updated_rbac_index).to eql(original_rbac_index + 1)
   end

--- a/spec/acceptance/index_spec.rb
+++ b/spec/acceptance/index_spec.rb
@@ -21,7 +21,7 @@ describe 'index file' do
   it 'treats run as the first when first_run failed' do
     index_fail_reset
     first_run_count = puppetserver.run_shell("grep 'first run' #{LOGDIR}/pe_event_forwarding.log -c", expect_failures: true).stdout.to_i
-    expect(first_run_count).to be(6)
+    expect(first_run_count).to eq(7)
   end
 
   it 'updates orchestrator index value' do

--- a/spec/acceptance/plan_index_spec.rb
+++ b/spec/acceptance/plan_index_spec.rb
@@ -4,17 +4,17 @@ require 'yaml'
 describe 'plan index file' do
   before(:all) do
     set_sitepp_content(declare('class', 'pe_event_forwarding', { 'pe_token' => auth_token, 'disabled' => true, 'log_level' => 'DEBUG' }))
-    trigger_puppet_run(puppetserver)
-    puppetserver.run_shell("#{CONFDIR}/pe_event_forwarding/collect_api_events.rb")
+    trigger_puppet_run(TARGET_SERVER)
+    TARGET_SERVER.run_shell("#{CONFDIR}/pe_event_forwarding/collect_api_events.rb")
   end
 
   after(:all) do
     set_sitepp_content(declare('class', 'pe_event_forwarding', { 'pe_token' => auth_token, 'disabled' => true, 'log_level' => 'DEBUG' }))
-    trigger_puppet_run(puppetserver)
+    trigger_puppet_run(TARGET_SERVER)
   end
 
   it 'plan index file exists after first run' do
-    expect(puppetserver.file_exists?("#{CONFDIR}/pe_event_forwarding/pe_event_forwarding_plan_index.yaml")).to be true
+    expect(TARGET_SERVER.file_exists?("#{CONFDIR}/pe_event_forwarding/pe_event_forwarding_plan_index.yaml")).to be true
   end
 
   it 'contains expected keys' do
@@ -24,8 +24,8 @@ describe 'plan index file' do
 
   it 'advances last_finished and populates ids after a plan job completes' do
     initial_ts = get_plan_index['last_finished']
-    puppetserver.run_shell("LC_ALL=en_US.UTF-8 puppet plan run facts targets=#{console_host_fqdn}")
-    puppetserver.run_shell("#{CONFDIR}/pe_event_forwarding/collect_api_events.rb")
+    TARGET_SERVER.run_shell("LC_ALL=en_US.UTF-8 puppet plan run facts targets=#{console_host_fqdn}")
+    TARGET_SERVER.run_shell("#{CONFDIR}/pe_event_forwarding/collect_api_events.rb")
     updated = get_plan_index
     expect(updated['last_finished']).not_to eq(initial_ts)
     expect(updated['ids_at_last_finished']).not_to be_empty
@@ -34,14 +34,14 @@ describe 'plan index file' do
   describe 'skip_plans behavior' do
     it 'when skip_plans is true, plan index last_finished is nil' do
       disable_plan_collection
-      puppetserver.run_shell("#{CONFDIR}/pe_event_forwarding/collect_api_events.rb")
+      TARGET_SERVER.run_shell("#{CONFDIR}/pe_event_forwarding/collect_api_events.rb")
       index = get_plan_index
       expect(index['last_finished']).to be_nil
     end
 
     it 'when plan collection is re-enabled, last_finished is set to a non-nil value' do
       enable_plan_collection
-      puppetserver.run_shell("#{CONFDIR}/pe_event_forwarding/collect_api_events.rb")
+      TARGET_SERVER.run_shell("#{CONFDIR}/pe_event_forwarding/collect_api_events.rb")
       index = get_plan_index
       expect(index['last_finished']).not_to be_nil
     end

--- a/spec/acceptance/plan_index_spec.rb
+++ b/spec/acceptance/plan_index_spec.rb
@@ -1,0 +1,49 @@
+require 'spec_helper_acceptance'
+require 'yaml'
+
+describe 'plan index file' do
+  before(:all) do
+    set_sitepp_content(declare('class', 'pe_event_forwarding', { 'pe_token' => auth_token, 'disabled' => true, 'log_level' => 'DEBUG' }))
+    trigger_puppet_run(puppetserver)
+    puppetserver.run_shell("#{CONFDIR}/pe_event_forwarding/collect_api_events.rb")
+  end
+
+  after(:all) do
+    set_sitepp_content(declare('class', 'pe_event_forwarding', { 'pe_token' => auth_token, 'disabled' => true, 'log_level' => 'DEBUG' }))
+    trigger_puppet_run(puppetserver)
+  end
+
+  it 'plan index file exists after first run' do
+    expect(puppetserver.file_exists?("#{CONFDIR}/pe_event_forwarding/pe_event_forwarding_plan_index.yaml")).to be true
+  end
+
+  it 'contains expected keys' do
+    index = get_plan_index
+    expect(index.keys).to include('last_finished', 'ids_at_last_finished')
+  end
+
+  it 'advances last_finished and populates ids after a plan job completes' do
+    initial_ts = get_plan_index['last_finished']
+    puppetserver.run_shell("LC_ALL=en_US.UTF-8 puppet plan run facts targets=#{console_host_fqdn}")
+    puppetserver.run_shell("#{CONFDIR}/pe_event_forwarding/collect_api_events.rb")
+    updated = get_plan_index
+    expect(updated['last_finished']).not_to eq(initial_ts)
+    expect(updated['ids_at_last_finished']).not_to be_empty
+  end
+
+  describe 'skip_plans behavior' do
+    it 'when skip_plans is true, plan index last_finished is nil' do
+      disable_plan_collection
+      puppetserver.run_shell("#{CONFDIR}/pe_event_forwarding/collect_api_events.rb")
+      index = get_plan_index
+      expect(index['last_finished']).to be_nil
+    end
+
+    it 'when plan collection is re-enabled, last_finished is set to a non-nil value' do
+      enable_plan_collection
+      puppetserver.run_shell("#{CONFDIR}/pe_event_forwarding/collect_api_events.rb")
+      index = get_plan_index
+      expect(index['last_finished']).not_to be_nil
+    end
+  end
+end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -77,6 +77,16 @@ describe 'pe_event_forwarding' do
           is_expected.to contain_cron('collect_pe_events')
             .with_command(%r{collect_api_events.rb*.*pe_event_forwarding.log*.*\/state\/pe_event_forwarding\/cache\/state})
         }
+
+        it {
+          is_expected.to contain_file("#{confdir_expectation}/pe_event_forwarding/collection_settings.yaml")
+            .with(mode: '0640')
+        }
+
+        it {
+          is_expected.to contain_file("#{confdir_expectation}/pe_event_forwarding/collection_secrets.yaml")
+            .with(mode: '0600')
+        }
       end
 
       context 'with cron disabled' do
@@ -93,6 +103,33 @@ describe 'pe_event_forwarding' do
             ensure: 'absent',
           )
         }
+      end
+
+      context 'with skip_plans => true' do
+        let(:params) do
+          {
+            pe_token: 'blah',
+            skip_plans: true,
+          }
+        end
+
+        it 'renders skip_plans: true in collection_settings.yaml' do
+          is_expected.to contain_file("#{confdir_expectation}/pe_event_forwarding/collection_settings.yaml")
+            .with_content(%r{"skip_plans"\s*:\s*true})
+        end
+      end
+
+      context 'with skip_plans not set (default)' do
+        let(:params) do
+          {
+            pe_token: 'blah',
+          }
+        end
+
+        it 'does not render skip_plans in collection_settings.yaml' do
+          is_expected.to contain_file("#{confdir_expectation}/pe_event_forwarding/collection_settings.yaml")
+            .without_content(%r{"skip_plans"})
+        end
       end
     end
   end

--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -9,28 +9,30 @@ CONFDIR = '/etc/puppetlabs'.freeze
 LOGDIR  = '/var/log/puppetlabs/pe_event_forwarding'.freeze
 LOCKFILEDIR = '/opt/puppetlabs/pe_event_forwarding/cache/state'.freeze
 
+TARGET_SERVER = Target.new(ENV['TARGET_HOST'])
+
 RSpec.configure do |config|
   include TargetHelpers
 
   config.before(:suite) do
     # Stop the puppet service on the puppetserver to avoid edge-case conflicting
     # Puppet runs (one triggered by service vs one we trigger)
-    puppetserver.run_shell('puppet resource service puppet ensure=stopped')
+    TARGET_SERVER.run_shell('puppet resource service puppet ensure=stopped')
     acceptance_setup
   end
 end
 
 def acceptance_setup
   set_sitepp_content(declare('class', 'pe_event_forwarding', { 'pe_token' => auth_token, 'disabled' => true, 'log_level' => 'DEBUG' }))
-  trigger_puppet_run(puppetserver)
+  trigger_puppet_run(TARGET_SERVER)
 end
 
 def console_host_fqdn
-  @console_host_fqdn ||= puppetserver.run_shell('hostname -A').stdout.strip
+  @console_host_fqdn ||= TARGET_SERVER.run_shell('hostname -A').stdout.strip
 end
 
 def auth_token
-  @auth_token ||= puppetserver.run_shell('puppet access show').stdout.chomp
+  @auth_token ||= TARGET_SERVER.run_shell('puppet access show').stdout.chomp
 end
 
 # TODO: This will cause some problems if we run the tests
@@ -43,8 +45,8 @@ def set_sitepp_content(manifest)
   }
   HERE
 
-  puppetserver.write_file(content, '/etc/puppetlabs/code/environments/production/manifests/site.pp')
-  puppetserver.run_shell('chown pe-puppet:pe-puppet /etc/puppetlabs/code/environments/production/manifests/site.pp')
+  TARGET_SERVER.write_file(content, '/etc/puppetlabs/code/environments/production/manifests/site.pp')
+  TARGET_SERVER.run_shell('chown pe-puppet:pe-puppet /etc/puppetlabs/code/environments/production/manifests/site.pp')
 end
 
 def trigger_puppet_run(target, acceptable_exit_codes: [0, 2])
@@ -94,12 +96,12 @@ end
 
 def upload_rbac_script
   file_path = 'spec/support/acceptance/generate_rbac_event.rb'
-  puppetserver.bolt_upload_file(file_path, "#{CONFDIR}/pe_event_forwarding/")
-  puppetserver.run_shell("chmod +x #{CONFDIR}/pe_event_forwarding/generate_rbac_event.rb")
+  TARGET_SERVER.bolt_upload_file(file_path, "#{CONFDIR}/pe_event_forwarding/")
+  TARGET_SERVER.run_shell("chmod +x #{CONFDIR}/pe_event_forwarding/generate_rbac_event.rb")
 end
 
 def get_service_index(service_symbol)
-  index_contents = puppetserver.run_shell("#{CONFDIR}/pe_event_forwarding/collect_api_events.rb ; cat #{CONFDIR}/pe_event_forwarding/pe_event_forwarding_indexes.yaml").stdout
+  index_contents = TARGET_SERVER.run_shell("#{CONFDIR}/pe_event_forwarding/collect_api_events.rb ; cat #{CONFDIR}/pe_event_forwarding/pe_event_forwarding_indexes.yaml").stdout
   index = YAML.safe_load(index_contents, permitted_classes: [Symbol])
   index[service_symbol]
 end
@@ -115,16 +117,16 @@ def enable_rbac_events
 end
 
 def index_fail_reset
-  puppetserver.run_shell('systemctl stop pe-orchestration-services')
-  puppetserver.run_shell("rm #{CONFDIR}/pe_event_forwarding/pe_event_forwarding_indexes.yaml")
-  puppetserver.run_shell("cat /dev/null > #{LOGDIR}/pe_event_forwarding.log")
-  puppetserver.run_shell("#{CONFDIR}/pe_event_forwarding/collect_api_events.rb")
-  puppetserver.run_shell('systemctl start pe-orchestration-services')
-  puppetserver.run_shell("#{CONFDIR}/pe_event_forwarding/collect_api_events.rb")
+  TARGET_SERVER.run_shell('systemctl stop pe-orchestration-services')
+  TARGET_SERVER.run_shell("rm #{CONFDIR}/pe_event_forwarding/pe_event_forwarding_indexes.yaml")
+  TARGET_SERVER.run_shell("cat /dev/null > #{LOGDIR}/pe_event_forwarding.log")
+  TARGET_SERVER.run_shell("#{CONFDIR}/pe_event_forwarding/collect_api_events.rb")
+  TARGET_SERVER.run_shell('systemctl start pe-orchestration-services')
+  TARGET_SERVER.run_shell("#{CONFDIR}/pe_event_forwarding/collect_api_events.rb")
 end
 
 def get_plan_index
-  contents = puppetserver.run_shell("cat #{CONFDIR}/pe_event_forwarding/pe_event_forwarding_plan_index.yaml").stdout
+  contents = TARGET_SERVER.run_shell("cat #{CONFDIR}/pe_event_forwarding/pe_event_forwarding_plan_index.yaml").stdout
   YAML.safe_load(contents)
 end
 

--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -122,3 +122,18 @@ def index_fail_reset
   puppetserver.run_shell('systemctl start pe-orchestration-services')
   puppetserver.run_shell("#{CONFDIR}/pe_event_forwarding/collect_api_events.rb")
 end
+
+def get_plan_index
+  contents = puppetserver.run_shell("cat #{CONFDIR}/pe_event_forwarding/pe_event_forwarding_plan_index.yaml").stdout
+  YAML.safe_load(contents)
+end
+
+def disable_plan_collection
+  set_sitepp_content(declare('class', 'pe_event_forwarding', { 'pe_token' => auth_token, 'disabled' => true, 'skip_plans' => true }))
+  trigger_puppet_run(puppetserver)
+end
+
+def enable_plan_collection
+  set_sitepp_content(declare('class', 'pe_event_forwarding', { 'pe_token' => auth_token, 'disabled' => true }))
+  trigger_puppet_run(puppetserver)
+end

--- a/spec/support/acceptance/helpers.rb
+++ b/spec/support/acceptance/helpers.rb
@@ -58,34 +58,25 @@ class TargetNotFoundError < StandardError; end
 
 module TargetHelpers
   def puppetserver
-    target('puppetserver', 'acceptance:provision_vms', 'server')
+    targets('puppetserver', 'acceptance:provision_vms', 'server')
   end
   module_function :puppetserver
 
-  def localhost
-    target('localhost', 'acceptance:provision_vms', 'localhost')
-  end
-
-  def target(name, setup_task, role)
+  def targets(name, setup_task, role)
     @targets ||= {}
 
     unless @targets[name]
-      # Find the target
       inventory_hash = LitmusHelpers.inventory_hash_from_inventory_file
-      targets = LitmusHelpers.find_targets(inventory_hash, nil)
-      target_uri = targets.find do |target|
-        vars = LitmusHelpers.vars_from_node(inventory_hash, target) || {}
-        (vars['role'] || []) == role
-      end
-      unless target_uri
+      uris = LitmusHelpers.nodes_with_role(role, inventory_hash)
+      unless uris
         raise TargetNotFoundError, "none of the targets in 'inventory.yaml' have the '#{role}' role set. Did you forget to run 'rake #{setup_task}'?"
       end
-      @targets[name] = Target.new(target_uri)
+      @targets[name] = uris.map { |uri| Target.new(uri) }
     end
 
     @targets[name]
   end
-  module_function :target
+  module_function :targets
 end
 
 module LitmusHelpers

--- a/spec/unit/api/pe_event_forwarding/activity_spec.rb
+++ b/spec/unit/api/pe_event_forwarding/activity_spec.rb
@@ -1,0 +1,119 @@
+require 'spec_helper'
+require_relative '../../../../files/api/activity'
+
+describe PeEventForwarding::Activity do
+  subject(:activity) { described_class.new('dummy', token: 'token') }
+
+  # activity.rb uses log.debug (not log&.debug), so we need a verifying double against ::Logger
+  let(:logger) { instance_double(::Logger, debug: nil) }
+
+  before(:each) do
+    activity.pe_client = instance_double('PeEventForwarding::PeHttp')
+    activity.log = logger
+  end
+
+  context '#get_events' do
+    # The PE Activity API calls individual event records "commits" — each commit
+    # is a transaction (e.g. an RBAC change, a classifier update). Internally
+    # get_events iterates response_body['commits'] and re-exposes them as 'events'.
+    let(:commits) { [{ 'id' => 1 }, { 'id' => 2 }] }
+    let(:pagination) { { 'total' => 10 } }
+
+    it 'returns events and total count from a single page' do
+      body = { 'commits' => commits, 'pagination' => pagination }.to_json
+      response = instance_double('response', body: body, code: '200')
+      allow(activity.pe_client).to receive(:pe_get_request).and_return(response)
+
+      result = activity.get_events(service: :rbac, api_page_size: 100, timeout: 5)
+      expect(result['events'].count).to eq(2)
+      expect(result['api_total_count']).to eq(10)
+    end
+
+    it 'stops paginating when the page is shorter than api_page_size' do
+      body = { 'commits' => commits, 'pagination' => pagination }.to_json
+      response = instance_double('response', body: body, code: '200')
+      expect(activity.pe_client).to receive(:pe_get_request).once.and_return(response)
+
+      # api_page_size 5, only 2 commits returned -> 2 != 5 -> break after one page
+      activity.get_events(service: :rbac, api_page_size: 5, timeout: 5)
+    end
+
+    it 'paginates when a full page is returned' do
+      full_page = [{ 'id' => 0 }, { 'id' => 1 }]
+      body1 = { 'commits' => full_page, 'pagination' => pagination }.to_json
+      body2 = { 'commits' => [], 'pagination' => pagination }.to_json
+      response1 = instance_double('response', body: body1, code: '200')
+      response2 = instance_double('response', body: body2, code: '200')
+      expect(activity.pe_client).to receive(:pe_get_request).twice.and_return(response1, response2)
+
+      # api_page_size 2, first page full -> continues; second page empty -> 0 != 2 -> break
+      result = activity.get_events(service: :rbac, api_page_size: 2, timeout: 5)
+      expect(result['events'].count).to eq(2)
+    end
+
+    it 'handles nil commits without raising' do
+      body = { 'commits' => nil, 'pagination' => { 'total' => 0 } }.to_json
+      response = instance_double('response', body: body, code: '200')
+      allow(activity.pe_client).to receive(:pe_get_request).and_return(response)
+
+      result = activity.get_events(service: :rbac, api_page_size: 10, timeout: 5)
+      expect(result['events']).to be_empty
+    end
+
+    it 'raises when API returns non-200' do
+      body = { 'commits' => [], 'pagination' => { 'total' => 0 } }.to_json
+      response = instance_double('response', body: body, code: '500')
+      allow(activity.pe_client).to receive(:pe_get_request).and_return(response)
+
+      expect { activity.get_events(service: :rbac, api_page_size: 10, timeout: 5) }
+        .to raise_error(RuntimeError, 'Events API request failed')
+    end
+  end
+
+  context '#current_event_count' do
+    it 'returns the total count from pagination' do
+      body = { 'pagination' => { 'total' => 42 } }.to_json
+      response = instance_double('response', body: body, code: '200')
+      allow(activity.pe_client).to receive(:pe_get_request).and_return(response)
+
+      expect(activity.current_event_count(:rbac, 5)).to eq(42)
+    end
+
+    it 'returns 0 when total is nil' do
+      body = { 'pagination' => {} }.to_json
+      response = instance_double('response', body: body, code: '200')
+      allow(activity.pe_client).to receive(:pe_get_request).and_return(response)
+
+      expect(activity.current_event_count(:rbac, 5)).to eq(0)
+    end
+
+    it 'raises when API returns non-200' do
+      response = instance_double('response', body: {}.to_json, code: '500')
+      allow(activity.pe_client).to receive(:pe_get_request).and_return(response)
+
+      expect { activity.current_event_count(:rbac, 5) }
+        .to raise_error(RuntimeError, 'Events API request failed')
+    end
+  end
+
+  # rubocop:disable RSpec/SubjectStub
+  context '#new_data' do
+    it 'returns nil when event count has not changed' do
+      allow(activity).to receive(:current_event_count).and_return(5)
+      expect(activity.new_data(:rbac, 5, 100, 30)).to be_nil
+    end
+
+    it 'returns nil when event count decreased' do
+      allow(activity).to receive(:current_event_count).and_return(3)
+      expect(activity.new_data(:rbac, 5, 100, 30)).to be_nil
+    end
+
+    it 'calls get_events with the correct offset when new events exist' do
+      allow(activity).to receive(:current_event_count).and_return(7)
+      expect(activity).to receive(:get_events)
+        .with(service: :rbac, offset: 5, api_page_size: 100, timeout: 30)
+      activity.new_data(:rbac, 5, 100, 30)
+    end
+  end
+  # rubocop:enable RSpec/SubjectStub
+end

--- a/spec/unit/api/pe_event_forwarding/orchestrator_spec.rb
+++ b/spec/unit/api/pe_event_forwarding/orchestrator_spec.rb
@@ -1,0 +1,196 @@
+require 'spec_helper'
+require_relative '../../../../files/api/orchestrator'
+
+describe PeEventForwarding::Orchestrator do
+  subject(:orchestrator) { described_class.new('dummy', token: 'token') }
+
+  before(:each) do
+    orchestrator.pe_client = instance_double('PeEventForwarding::PeHttp')
+  end
+
+  context '#parse_timestamp' do
+    it 'returns nil for nil input' do
+      expect(orchestrator.parse_timestamp(nil)).to be_nil
+    end
+
+    it 'parses ISO8601 timestamp to float' do
+      ts = '2020-01-02T03:04:05Z'
+      expect(orchestrator.parse_timestamp(ts)).to be_within(0.001).of(Time.parse(ts).to_f)
+    end
+
+    it 'returns numeric for numeric strings' do
+      expect(orchestrator.parse_timestamp('123.456')).to eq(123.456)
+    end
+  end
+
+  context '#plan_job_finished_timestamp' do
+    it 'returns the finished_timestamp field' do
+      expect(orchestrator.plan_job_finished_timestamp({ 'finished_timestamp' => 'a' })).to eq('a')
+    end
+
+    it 'returns nil when finished_timestamp is absent' do
+      expect(orchestrator.plan_job_finished_timestamp({ 'name' => 'j1' })).to be_nil
+    end
+  end
+
+  context '#get_plan_jobs_since' do
+    it 'fetches pages and returns finished jobs and max finished timestamp' do
+      items = [
+        { 'name' => 'j1', 'finished_timestamp' => '2020-01-01T00:00:00Z' },
+        { 'name' => 'j2', 'finished_timestamp' => '2020-01-02T00:00:00Z' },
+      ]
+      response1 = instance_double('response', body: { 'items' => items }.to_json, code: '200')
+      response2 = instance_double('response', body: { 'items' => [] }.to_json, code: '200')
+      allow(orchestrator.pe_client).to receive(:pe_get_request).and_return(response1, response2)
+
+      res = orchestrator.get_plan_jobs_since(min_finish_timestamp: nil, limit: 2, timeout: 5)
+      expect(res['events'].count).to eq(2)
+      expect(res['last_finished']).to eq('2020-01-02T00:00:00Z')
+    end
+
+    it 'filters out running jobs that have no finished timestamp' do
+      items = [
+        { 'name' => 'j1', 'finished_timestamp' => '2020-01-01T00:00:00Z' },
+        { 'name' => 'j2' },  # running – no timestamp field
+      ]
+      response1 = instance_double('response', body: { 'items' => items }.to_json, code: '200')
+      response2 = instance_double('response', body: { 'items' => [] }.to_json, code: '200')
+      allow(orchestrator.pe_client).to receive(:pe_get_request).and_return(response1, response2)
+
+      res = orchestrator.get_plan_jobs_since(min_finish_timestamp: nil, timeout: 5)
+      expect(res['events'].count).to eq(1)
+      expect(res['events'].first['name']).to eq('j1')
+    end
+
+    it 'returns empty events and nil last_finished when no jobs are finished' do
+      items = [{ 'name' => 'j1' }, { 'name' => 'j2' }]
+      response1 = instance_double('response', body: { 'items' => items }.to_json, code: '200')
+      response2 = instance_double('response', body: { 'items' => [] }.to_json, code: '200')
+      allow(orchestrator.pe_client).to receive(:pe_get_request).and_return(response1, response2)
+
+      res = orchestrator.get_plan_jobs_since(min_finish_timestamp: nil, timeout: 5)
+      expect(res['events']).to be_empty
+      expect(res['last_finished']).to be_nil
+    end
+  end
+
+  # rubocop:disable RSpec/SubjectStub
+  context '#new_plan_data_by_finish' do
+    it 'dedupes inclusive results using processed_ids and returns remaining events' do
+      res_hash = {
+        'last_finished' => '2020-01-02T00:00:00Z',
+        'events' => [
+          { 'name' => 'j2', 'finished_timestamp' => '2020-01-02T00:00:00Z' },
+          { 'name' => 'j3', 'finished_timestamp' => '2020-01-03T00:00:00Z' },
+        ],
+      }
+      allow(orchestrator).to receive(:get_plan_jobs_since).and_return(res_hash)
+
+      result = orchestrator.new_plan_data_by_finish('2020-01-02T00:00:00Z', 5, processed_ids: ['j2'])
+      expect(result).not_to be_nil
+      expect(result['events'].map { |j| j['name'] }).to eq(['j3'])
+      expect(result['last_finished']).to eq('2020-01-03T00:00:00Z')
+    end
+
+    it 'returns nil when there are no finished events' do
+      allow(orchestrator).to receive(:get_plan_jobs_since)
+        .and_return({ 'last_finished' => nil, 'events' => [] })
+      expect(orchestrator.new_plan_data_by_finish('2020-01-01T00:00:00Z', 5)).to be_nil
+    end
+
+    it 'returns nil when all events are removed by processed_ids dedupe' do
+      res_hash = {
+        'last_finished' => '2020-01-01T00:00:00Z',
+        'events' => [{ 'name' => 'j1', 'finished_timestamp' => '2020-01-01T00:00:00Z' }],
+      }
+      allow(orchestrator).to receive(:get_plan_jobs_since).and_return(res_hash)
+      expect(orchestrator.new_plan_data_by_finish('2020-01-01T00:00:00Z', 5, processed_ids: ['j1'])).to be_nil
+    end
+
+    it 'sorts events ascending by finished timestamp' do
+      res_hash = {
+        'last_finished' => '2020-01-03T00:00:00Z',
+        'events' => [
+          { 'name' => 'j3', 'finished_timestamp' => '2020-01-03T00:00:00Z' },
+          { 'name' => 'j1', 'finished_timestamp' => '2020-01-01T00:00:00Z' },
+          { 'name' => 'j2', 'finished_timestamp' => '2020-01-02T00:00:00Z' },
+        ],
+      }
+      allow(orchestrator).to receive(:get_plan_jobs_since).and_return(res_hash)
+      result = orchestrator.new_plan_data_by_finish(nil, 5)
+      expect(result['events'].map { |j| j['name'] }).to eq(['j1', 'j2', 'j3'])
+    end
+  end
+  # rubocop:enable RSpec/SubjectStub
+
+  context '#get_jobs' do
+    it 'returns events and correct api_total_count' do
+      items = [{ 'name' => '2' }, { 'name' => '3' }]
+      response = instance_double('response', body: { 'items' => items }.to_json, code: '200')
+      allow(orchestrator.pe_client).to receive(:pe_get_request).and_return(response)
+
+      result = orchestrator.get_jobs(index_count: 1, new_jobs: 2, timeout: 5)
+      expect(result['events'].count).to eq(2)
+      expect(result['api_total_count']).to eq(3)
+    end
+
+    it 'paginates across multiple pages until new_jobs is satisfied' do
+      page1 = [{ 'name' => '2' }, { 'name' => '3' }]
+      page2 = [{ 'name' => '4' }]
+      response1 = instance_double('response', body: { 'items' => page1 }.to_json, code: '200')
+      response2 = instance_double('response', body: { 'items' => page2 }.to_json, code: '200')
+      allow(orchestrator.pe_client).to receive(:pe_get_request).and_return(response1, response2)
+
+      result = orchestrator.get_jobs(index_count: 1, new_jobs: 3, limit: 2, timeout: 5)
+      expect(result['events'].count).to eq(3)
+    end
+
+    it 'raises when API returns non-200' do
+      response = instance_double('response', body: { 'items' => [] }.to_json, code: '500')
+      allow(orchestrator.pe_client).to receive(:pe_get_request).and_return(response)
+      expect { orchestrator.get_jobs(index_count: 0, new_jobs: 0, timeout: 5) }
+        .to raise_error(RuntimeError, 'Orchestrator API request failed')
+    end
+  end
+
+  context '#current_job_count' do
+    it 'returns 0 when items is empty' do
+      response = instance_double('response', body: { 'items' => [] }.to_json, code: '200')
+      allow(orchestrator.pe_client).to receive(:pe_get_request).and_return(response)
+      expect(orchestrator.current_job_count(5)).to eq(0)
+    end
+
+    it 'returns the integer name of the most recent job' do
+      response = instance_double('response', body: { 'items' => [{ 'name' => '42' }] }.to_json, code: '200')
+      allow(orchestrator.pe_client).to receive(:pe_get_request).and_return(response)
+      expect(orchestrator.current_job_count(5)).to eq(42)
+    end
+
+    it 'raises when API returns non-200' do
+      response = instance_double('response', body: {}.to_json, code: '500')
+      allow(orchestrator.pe_client).to receive(:pe_get_request).and_return(response)
+      expect { orchestrator.current_job_count(5) }
+        .to raise_error(RuntimeError, 'Orchestrator API request failed')
+    end
+  end
+
+  # rubocop:disable RSpec/SubjectStub
+  context '#new_data' do
+    it 'returns nil when job count has not changed' do
+      allow(orchestrator).to receive(:current_job_count).and_return(5)
+      expect(orchestrator.new_data(5, 30)).to be_nil
+    end
+
+    it 'returns nil when job count decreased' do
+      allow(orchestrator).to receive(:current_job_count).and_return(3)
+      expect(orchestrator.new_data(5, 30)).to be_nil
+    end
+
+    it 'calls get_jobs with correct args when new jobs exist' do
+      allow(orchestrator).to receive(:current_job_count).and_return(7)
+      expect(orchestrator).to receive(:get_jobs).with(index_count: 5, new_jobs: 2, timeout: 30)
+      orchestrator.new_data(5, 30)
+    end
+  end
+  # rubocop:enable RSpec/SubjectStub
+end

--- a/spec/unit/util/pe_event_forwarding/plan_index_spec.rb
+++ b/spec/unit/util/pe_event_forwarding/plan_index_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+require_relative '../../../../files/util/plan_index'
+
+describe PeEventForwarding::PlanIndex do
+  subject(:plan_index) { described_class.new(statedir) }
+
+  let(:statedir) { 'blah' }
+  let(:filepath) { "#{statedir}/pe_event_forwarding_plan_index.yaml" }
+  let(:initial_yaml) { { 'last_finished' => nil, 'ids_at_last_finished' => [] }.to_yaml }
+
+  before(:each) do
+    allow(File).to receive(:exist?).with(filepath).and_return(true)
+    allow(File).to receive(:read).and_return(initial_yaml)
+  end
+
+  context '.initialize' do
+    context 'file does not already exist' do
+      before(:each) do
+        allow(File).to receive(:exist?).with(filepath).and_return(false)
+      end
+
+      it 'creates a new file with correct content' do
+        expect(File).to receive(:write).with(filepath, initial_yaml)
+        plan_index
+      end
+    end
+
+    context 'file does exist' do
+      it 'does not create a new file' do
+        expect(File).not_to receive(:write)
+        plan_index
+      end
+
+      it 'returns nil for last_finished when file contains nil' do
+        expect(plan_index.last_finished).to be_nil
+      end
+    end
+  end
+
+  context '.save' do
+    it 'writes correct yaml with provided values' do
+      expect(File).to receive(:write).with(filepath, { 'last_finished' => 123, 'ids_at_last_finished' => ['a'] }.to_yaml)
+      plan_index.save(last_finished: 123, ids: ['a'])
+    end
+  end
+end

--- a/spec/unit/util/pe_event_forwarding/processor_spec.rb
+++ b/spec/unit/util/pe_event_forwarding/processor_spec.rb
@@ -27,7 +27,9 @@ describe PeEventForwarding::Processor do
         end
 
         it 'returns correct number of processors' do
-          expect(described_class.find_each(procs_dir).count).to eq(2)
+          processors = []
+          described_class.find_each(procs_dir) { |p| processors << p }
+          expect(processors.count).to eq(2)
         end
 
         it 'returns correct object types' do
@@ -39,11 +41,13 @@ describe PeEventForwarding::Processor do
 
       context 'no processors present' do
         before(:each) do
-          allow(Find).to receive(:find).with(procs_dir).and_return([])
+          allow(described_class).to receive(:dir_listing).with(procs_dir).and_return([])
         end
 
         it 'returns no processors' do
-          expect(described_class.find_each(procs_dir).count).to eq(0)
+          processors = []
+          described_class.find_each(procs_dir) { |p| processors << p }
+          expect(processors).to be_empty
         end
       end
     end

--- a/tasks/install_pe.json
+++ b/tasks/install_pe.json
@@ -1,0 +1,15 @@
+{
+  "description": "Download and install Puppet Enterprise on a target node",
+  "input_method": "environment",
+  "private": true,
+  "parameters": {
+    "url": {
+      "description": "The full HTTPS URL to the PE installer tarball",
+      "type": "String[1]"
+    },
+    "console_password": {
+      "description": "The PE console admin password",
+      "type": "String[1]"
+    }
+  }
+}

--- a/tasks/install_pe.sh
+++ b/tasks/install_pe.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+#
+# @summary Download and install PE
+# @api private
+#
+# Download and install Puppet Enterprise on a target node.
+#
+# Task parameters:
+#   PT_url                - Full HTTPS URL to the PE installer tarball
+#   PT_console_password   - PE console admin password
+export LANG=en_US.UTF-8
+
+_tmp_stderr="$(mktemp)"
+exec 2>>"$_tmp_stderr"
+
+fail() {
+  if [[ -s "$_tmp_stderr" ]]; then
+    echo "{ \"status\": \"error\", \"message\": \"$1\", \"stderr\": \"$(tr '\n' ' ' <"$_tmp_stderr")\" }"
+  else
+    echo "{ \"status\": \"error\", \"message\": \"$1\" }"
+  fi
+  exit "${2:-1}"
+}
+
+success() {
+  echo "$1"
+  exit 0
+}
+
+# Unpack PT_* environment variables into plain names
+for v in ${!PT_*}; do
+  declare "${v#*PT_}"="${!v}"
+done
+
+(( EUID == 0 )) || fail "This task must be run as root"
+
+[[ -n "$url" ]]              || fail "url parameter is required"
+[[ -n "$console_password" ]] || fail "console_password parameter is required"
+
+_work_dir="$(mktemp -d)"
+cd "$_work_dir" || fail "Failed to create working directory"
+
+echo "Downloading PE tarball from: $url"
+curl -Lf "$url" -o pe.tar.gz || fail "Failed to download PE tarball from: $url"
+
+echo "Extracting PE tarball..."
+tar xf pe.tar.gz || fail "Failed to extract PE tarball"
+
+pe_dir=$(find "$_work_dir" -maxdepth 1 -type d -name 'puppet-enterprise-*' | head -1)
+[[ -n "$pe_dir" ]] || fail "Could not find extracted PE directory in $_work_dir"
+
+# Write a minimal pe.conf
+cat > "$_work_dir/pe.conf" <<PECONF
+{
+  "console_admin_password": "${console_password}"
+  "puppet_enterprise::puppet_master_host": "%{::trusted.certname}"
+  "pe_install::puppet_master_dnsaltnames": ["puppet"]
+  "puppet_enterprise::profile::master::check_for_updates": false
+  "puppet_enterprise::send_analytics_data": false
+}
+PECONF
+
+echo "Starting PE installation (this may take several minutes)..."
+chmod +x "${pe_dir}/puppet-enterprise-installer"
+"${pe_dir}/puppet-enterprise-installer" -y -c "$_work_dir/pe.conf" \
+  || fail "PE installation failed"
+
+echo "Running Puppet agent (pass 1 of 2)..."
+/opt/puppetlabs/bin/puppet agent -t; true
+
+echo "Running Puppet agent (pass 2 of 2)..."
+/opt/puppetlabs/bin/puppet agent -t; true

--- a/templates/collection_settings.yaml.epp
+++ b/templates/collection_settings.yaml.epp
@@ -18,6 +18,9 @@
 <% if $pe_event_forwarding::skip_jobs{ -%>
 "skip_jobs" : <%= $pe_event_forwarding::skip_jobs %>
 <% } -%>
+<% if $pe_event_forwarding::skip_plans{ -%>
+"skip_plans" : <%= $pe_event_forwarding::skip_plans %>
+<% } -%>
 <% if $pe_event_forwarding::timeout{ -%>
 "timeout" : "<%= $pe_event_forwarding::timeout %>"
 <% } -%>


### PR DESCRIPTION
# Summary

This commit adds collection of Puppet orchestrator **plan job data** as a new event source, introduces a `skip_plans` parameter for opt-out parity with the existing `skip_jobs` parameter, and includes general code maintenance (bug fixes and refactoring) alongside PDK rubocop compliance corrections.

# Detailed Description

#### Plan Jobs Data

* `files/api/orchestrator.rb`
  * Added `parse_timestamp`, `plan_job_finished_timestamp`, `get_plan_jobs_since`, and `new_plan_data_by_finish` — the full API layer for fetching and filtering orchestrator plan jobs, including pagination, deduplication by processed IDs, and ascending sort by finish time
* `files/util/plan_index.rb`
  * Persistent index file for plan job collection state — tracks `last_finished` timestamp and `ids` (dedup set for inclusive queries) across runs, analogous to the existing job/activity index
* `files/collect_api_events.rb`
  * Added the plan jobs collection block
    * Calls orchestrator.new_plan_data_by_finish, stores result in data[:orchestrator_plan], computes processed_ids, and persists the plan index
    * When skip_plans is set on first run the plan index is intentionally left uninitialized
    * On re-enable the main loop detects the nil and snapshots Time.now as the checkpoint, ensuring no historical backlog is collected
* `manifests/init.pp`
  * Added `$skip_plans` parameter (mirrors `$skip_jobs`) to allow operators to disable plan job collection
* `templates/collection_settings.yaml.epp`
  * Conditionally emits `skip_plans: true` when `$skip_plans` is set
* `README.md`
  * Documents the Plan Jobs API event source, the `orchestrator_plan` payload structure in the forwarded data example, `pe_event_forwarding_plan_index.yaml` in the Resources section, and `skip_plans` in Advanced Configuration
* `CHANGELOG.md`
  * Documented changes
* `metadata.json`
  * Version bump to 2.3.0
* `files/util/plan_index_spec.rb`
  * Acceptance tests for plan index collection end-to-end behaviour
* `spec/classes/init_spec.rb`
  * Added coverage for `skip_plans` parameter
* `spec/unit/api/pe_event_forwarding/orchestrator_spec.rb`
  * Added contexts for `#parse_timestamp`, `#plan_job_finished_timestamp`, `#get_plan_jobs_since`, and `#new_plan_data_by_finish`
* `spec/unit/util/pe_event_forwarding/plan_index_spec.rb`
  * Unit tests for `PlanIndex` — save/load, first-run defaults, and re-enable guard

---

#### General Maintenance

* `files/api/activity.rb`
  * `map`→`each` (result was unused); extracted `commits` as a local variable to avoid double-calling `response_body['commits']` and to make the pagination break condition read off the same reference
* `files/api/orchestrator.rb`
  * `map`→`each` in items accumulation loop
  * `!processed_ids.nil? && !processed_ids.empty?` → `processed_ids.any?`
  * `!method.nil?` guards → truthy checks
* `files/collect_api_events.rb`
  * Fixed always-true guard condition: `!v.nil? || v != -1` → `!v.nil? && v != -1`
  * Replaced all `skip_*` `.nil?` checks with truthy checks (consistent with YAML template contract where the key is either `true` or absent)
  * Moved activity services loop before orchestrator/plan blocks for logical ordering
* `files/util/http.rb`
  * Fixed silent bug: `ca_cert:` → `ca_file:` in `get_request` (Net::HTTP ignores unknown keys, so custom CA certificates were silently not applied to GET requests)
* `files/util/processor.rb`
  * Simplified `find_each`: replaced `select`+`block_given?`+`unless` with `each`+`next if`+direct `yield`
  * Removed the dead no-block accumulator path (all call sites always pass a block)
* `spec/unit/api/pe_event_forwarding/activity_spec.rb`
  * Full unit test coverage for `Activity` — previously untested
    * Covers `#get_events` pagination, `#current_event_count`, and `#new_data`
* `spec/unit/util/pe_event_forwarding/processor_spec.rb`
  * Updated `#find_each` tests to use a block (bare `.count` on the return value would `LocalJumpError` with the simplified implementation)
  * Replaced non-functional `Find.find` stub with a `dir_listing` stub that actually matches the implementation

---

#### PDK Changes

* `files/api/orchestrator.rb`
  * Removed redundant `return` in `get_plan_jobs_since` (autocorrected by rubocop)
* `files/collect_api_events.rb`
  * Double-quoted string literal changed to single-quoted
  * `do...end` block on chained call changed to `{...}` brace block
* `files/util.index.rb`
  * Conditional variable assignment rewritten to use the return value of the conditional
  * Corrected indentation and `else`/`end` alignment
* `spec/unit/api/pe_event_forwarding/activity_spec.rb`
  * `before` → `before(:each)`; `double('logger')` → `instance_double(::Logger)`
  * two spy-pattern assertions (`allow` + `have_received` after the call) converted to `expect.to receive` before the call
  * `# rubocop:disable/enable RSpec/SubjectStub` added around `#new_data` context
* `spec/unit/api/pe_event_forwarding/orchestrator_spec.rb`
  * `before` → `before(:each)`
  * multiple `{ hash.to_json }` parenthesised method call arguments unwrapped
  * spacing fixes after colons; `%w[]` word array literal
  * removed spurious blank line
  * `# rubocop:disable/enable RSpec/SubjectStub` added around `#new_plan_data_by_finish` and `#new_data` contexts
* `REFERENCE.md`
  * Added `skip_plans` parameter entry

---

### Update acceptance testing setup

Drop Puppet 7 / PE 2021 support in line with EOL, and overhauls the acceptance testing infrastructure to support multi-target testing and align with patterns used in `puppetlabs-splunk_hec`.

* `metadata.json`
  * Dropped Puppet 7 support, raising the minimum version requirement to `>= 8.2.0` (PE 2023.4+) as Puppet 7 is EOL and PE 2021 is no longer supported
  * Updated OS support matrix to reflect current supported platforms

* `.github/workflows/integration_test.yml`
  * Updated `matrix_from_metadata_v3` flags — `ubuntu-(20|24).04` and `redhat-8` platform excludes now use regex patterns to be more precise; `--puppet-exclude 7` now naturally excludes PE 2021 via the metadata change
  * Removed the `platform` parameter from the `pe_server` plan invocation — platform is now derived from inventory facts
  * Removed the `add_localhost_target` step — no longer needed since the plan now uses `ctrl::sleep` instead of running a command on localhost
  * Changed `run_tests` → `ci_run_tests` to align with the multi-target test execution pattern

* `plans/acceptance/pe_server.pp`
  * Replaced `deploy_pe::provision_master` with a direct tarball download via the `pe_event_forwarding::install_pe` task — **significantly faster installs**
  * Removed `platform` parameter — platform is now derived from each server's inventory facts (`$server.facts['platform']`)
  * Switched to `ctrl::sleep(30)` to remove the dependency on a localhost inventory target

* `plans/acceptance/provision_machines.pp`
  * Updated default image from the EOL `centos-7-x86_64` to `redhat-8-x86_64`

* `provision.yaml`
  * Updated from `centos-7-x86_64` (EOL) to `redhat-8-x86_64` and `ubuntu-2404-x86_64` using the `abs` provisioner
  * Removed unused `master` and `agent` profiles

* `rakelib/helpers.rake`
  * Complete overhaul — removed dead ServiceNow leftover code (`servicenow_params`, `run_local_command`, `task_prefix`)
  * Renamed tasks to match `splunk_hec` conventions: `run_tests` for local execution, `ci_run_tests` for multi-target bolt-based execution, `ci_tests` for the full pipeline
  * `setup_pe` now raises on bolt failure and supports a `PE_VERSION` env var override
  * `install_module` now iterates over all servers with `reenable` between each invoke to ensure all targets receive the module
  * `add_localhost_target` removed — no longer needed
  * Added `spec_prep` as the first step in `setup` to ensure the fixtures directory is populated before bolt plans run

* `spec/support/acceptance/helpers.rb`
  * Updated `target()` to return an array of `Target` objects using `nodes_with_role`, matching `splunk_hec`'s multi-target pattern
  * Removed the `localhost` helper — no longer needed

* `spec/spec_helper_acceptance_local.rb` / `spec/acceptance/*.rb`
  * Introduced `TARGET_SERVER = Target.new(ENV['TARGET_HOST'])` — scopes each rspec process to the server under test as set by `provision::run_tests`, enabling correct multi-target test execution
  * Replaced all `puppetserver` / `puppetserver.first` references with `TARGET_SERVER`
  * Added helpers for plan index testing: `get_plan_index`, `disable_plan_collection`, `enable_plan_collection`
